### PR TITLE
feat: CI 파이프라인에 Redis 테스트 환경 구축 및 테스트 코드 추가

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -10,18 +10,20 @@ jobs:
   # build(test포함) 진행
   build:
     runs-on: ubuntu-latest
-
     steps:
       - name: Github Repository 파일 불러오기
         uses: actions/checkout@v4
-
       - name: JDK 17버전 설치
         uses: actions/setup-java@v4
         with:
           distribution: temurin
           java-version: 17
-      - name: .env 파일 만들기
-        run: echo "${{ secrets.ENV }}" > .env
+      - name: Redis 설치
+        uses: supercharge/redis-github-action@1.1.0
+        with:
+          redis-version: 6
+      - name: 테스트용 .env 파일 만들기
+        run: echo "${{ secrets.ENV_TEST }}" > .env
       - name: Grant execute permission to Gradle wrapper
         run: chmod +x ./gradlew
       - name: Build and run tests

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -17,6 +17,12 @@ jobs:
         with:
           distribution: temurin
           java-version: 17
+      - name: Redis 설치
+        uses: supercharge/redis-github-action@1.1.0
+        with:
+          redis-version: 6
+      - name: 테스트용 .env 파일 만들기
+        run: echo "${{ secrets.ENV_TEST }}" > .env
       - name: 테스트 및 빌드하기
         run: |
           sudo chmod +x gradlew

--- a/src/test/java/com/pawever/server/domain/cicd/service/RedisServiceMockTest.java
+++ b/src/test/java/com/pawever/server/domain/cicd/service/RedisServiceMockTest.java
@@ -1,0 +1,63 @@
+package com.pawever.server.domain.cicd.service;
+
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.MockitoAnnotations;
+import org.springframework.data.redis.core.RedisTemplate;
+import org.springframework.data.redis.core.ValueOperations;
+
+import static org.junit.jupiter.api.Assertions.*;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+class RedisServiceMockTest {
+    // Mock 객체로 Redis 테스트
+    @Mock
+    private RedisTemplate<String, String> redisTemplate; // RedisTemplate을 Mock 객체로 선언
+
+    @Mock
+    private ValueOperations<String, String> valueOperations; // ValueOperations을 Mock 객체로 선언
+
+    @InjectMocks
+    private RedisService redisService; // 테스트 대상 서비스
+
+    @BeforeEach
+    public void setUp() {
+        // Mockito 초기화
+        MockitoAnnotations.initMocks(this);
+
+        // opsForValue()를 Mock 객체로 설정
+        when(redisTemplate.opsForValue()).thenReturn(valueOperations);
+    }
+
+    @Test
+    public void testSaveValue() {
+        // Given: 테스트를 위한 값 설정
+        String key = "myKey";
+        String value = "myValue";
+
+        // When: saveValue 메서드 호출
+        redisService.saveValue(key, value);
+
+        // Then: RedisTemplate의 opsForValue().set() 메서드가 호출되었는지 검증
+        verify(valueOperations).set(key, value); // set() 메서드가 호출되었는지 검증
+        System.out.println("Redis Mock Test1 success");
+    }
+
+    @Test
+    public void testGetValue() {
+        // Given: RedisTemplate이 리턴할 값을 설정
+        String key = "myKey";
+        String expectedValue = "myValue";
+        when(valueOperations.get(key)).thenReturn(expectedValue); // mock 리턴 값 설정
+
+        // When: getValue 메서드 호출
+        String actualValue = redisService.getValue(key);
+
+        // Then: 값이 제대로 반환되는지 검증
+        assertEquals(expectedValue, actualValue); // 예상 값과 실제 값 비교
+        System.out.println("Redis Mock Test2 success");
+    }
+}

--- a/src/test/java/com/pawever/server/domain/cicd/service/RedisServiceTest.java
+++ b/src/test/java/com/pawever/server/domain/cicd/service/RedisServiceTest.java
@@ -1,60 +1,29 @@
 package com.pawever.server.domain.cicd.service;
 
-import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
-import org.mockito.InjectMocks;
-import org.mockito.Mock;
-import org.mockito.MockitoAnnotations;
-import org.springframework.data.redis.core.RedisTemplate;
-import org.springframework.data.redis.core.ValueOperations;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.context.SpringBootTest;
+import static org.assertj.core.api.Assertions.assertThat;
 
-import static org.junit.jupiter.api.Assertions.*;
-import static org.mockito.Mockito.verify;
-import static org.mockito.Mockito.when;
+@SpringBootTest
+public class RedisServiceTest {
+    // Mock 객체 없이 실제 Redis 테스트
 
-class RedisServiceTest {
-    @Mock
-    private RedisTemplate<String, String> redisTemplate; // RedisTemplate을 Mock 객체로 선언
-
-    @Mock
-    private ValueOperations<String, String> valueOperations; // ValueOperations을 Mock 객체로 선언
-
-    @InjectMocks
-    private RedisService redisService; // 테스트 대상 서비스
-
-    @BeforeEach
-    public void setUp() {
-        // Mockito 초기화
-        MockitoAnnotations.initMocks(this);
-
-        // opsForValue()를 Mock 객체로 설정
-        when(redisTemplate.opsForValue()).thenReturn(valueOperations);
-    }
+    @Autowired
+    private RedisService redisService;
 
     @Test
-    public void testSaveValue() {
-        // Given: 테스트를 위한 값 설정
-        String key = "myKey";
-        String value = "myValue";
+    public void testSaveAndGetValue() {
+        // given
+        String key = "testKey";
+        String value = "testValue";
 
-        // When: saveValue 메서드 호출
+        // when
         redisService.saveValue(key, value);
+        String retrievedValue = redisService.getValue(key);
 
-        // Then: RedisTemplate의 opsForValue().set() 메서드가 호출되었는지 검증
-        verify(valueOperations).set(key, value); // set() 메서드가 호출되었는지 검증
-    }
-
-    @Test
-    public void testGetValue() {
-        // Given: RedisTemplate이 리턴할 값을 설정
-        String key = "myKey";
-        String expectedValue = "myValue";
-        when(valueOperations.get(key)).thenReturn(expectedValue); // mock 리턴 값 설정
-
-        // When: getValue 메서드 호출
-        String actualValue = redisService.getValue(key);
-
-        // Then: 값이 제대로 반환되는지 검증
-        assertEquals(expectedValue, actualValue); // 예상 값과 실제 값 비교
+        // then
+        assertThat(retrievedValue).isEqualTo(value);
+        System.out.println("Redis Test without Mock success");
     }
 }

--- a/src/test/resources/application-test.yml
+++ b/src/test/resources/application-test.yml
@@ -1,4 +1,10 @@
 spring:
+  config:
+    import: optional:file:.env[.properties]
+  data:
+    redis:
+      host: ${REDIS_HOST_NAME}
+      port: ${REDIS_PORT}
   jpa:
     database-platform: org.hibernate.dialect.H2Dialect #추가
     show-sql: true
@@ -20,5 +26,5 @@ spring:
     console:
       settings:
         web-allow-others: true
-      enbaled : true
-      path : /h2
+      enabled: true
+      path: /h2


### PR DESCRIPTION
## #️⃣연관된 이슈

> #8

## 📝작업 내용

> CI 환경에서 mock객체가 아닌 실제 Redis 서버와 통신하여 테스트 할 수 있는 환경을 구축하였습니다.
- ci.yml, Deploy.yml에 supercharge/redis-github-action@1.1.0 라이브러리 추가
- ci.yml, Deploy.yml에서 Secrets로부터 ENV_TEST 값을 불러와서 .env 파일을 읽어오고 이를 application-test.yml에서 사용
- 실제 Redis를 사용하는 테스트 코드 추가(githubactions console를 통해 redis와 통신이 이루어지는지 확인 가능) 
 
![image](https://github.com/user-attachments/assets/31f4787b-8d21-40a4-90aa-dc0070473fd7)


## 💬리뷰 요구사항(선택)

> approve 부탁드립니다!


## ✅ 체크리스트

- [x] PR 제목 규칙 잘 지켰는가?
- [x] 추가/수정사항을 설명하였는가?
- [x] 이슈넘버를 적었는가?
