### PR TITLE
Feat/10 CI 환경에서 application-test.yml이 적용되지 않던 문제 해결

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -10,18 +10,20 @@ jobs:
   # build(test포함) 진행
   build:
     runs-on: ubuntu-latest
-
     steps:
       - name: Github Repository 파일 불러오기
         uses: actions/checkout@v4
-
       - name: JDK 17버전 설치
         uses: actions/setup-java@v4
         with:
           distribution: temurin
           java-version: 17
-      - name: .env 파일 만들기
-        run: echo "${{ secrets.ENV }}" > .env
+      - name: Redis 설치
+        uses: supercharge/redis-github-action@1.1.0
+        with:
+          redis-version: 6
+      - name: 테스트용 .env 파일 만들기
+        run: echo "${{ secrets.ENV_TEST }}" > .env
       - name: Grant execute permission to Gradle wrapper
         run: chmod +x ./gradlew
       - name: Build and run tests

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -17,6 +17,12 @@ jobs:
         with:
           distribution: temurin
           java-version: 17
+      - name: Redis 설치
+        uses: supercharge/redis-github-action@1.1.0
+        with:
+          redis-version: 6
+      - name: 테스트용 .env 파일 만들기
+        run: echo "${{ secrets.ENV_TEST }}" > .env
       - name: 테스트 및 빌드하기
         run: |
           sudo chmod +x gradlew

--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -2,7 +2,7 @@ spring:
   application:
     name: pawEver
   profiles:
-    active: dev
+    default: local
 logging:
   config: classpath:logback-spring.xml
 springdoc:

--- a/src/test/java/com/pawever/server/domain/cicd/service/RedisServiceMockTest.java
+++ b/src/test/java/com/pawever/server/domain/cicd/service/RedisServiceMockTest.java
@@ -1,0 +1,63 @@
+package com.pawever.server.domain.cicd.service;
+
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.MockitoAnnotations;
+import org.springframework.data.redis.core.RedisTemplate;
+import org.springframework.data.redis.core.ValueOperations;
+
+import static org.junit.jupiter.api.Assertions.*;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+class RedisServiceMockTest {
+    // Mock 객체로 Redis 테스트
+    @Mock
+    private RedisTemplate<String, String> redisTemplate; // RedisTemplate을 Mock 객체로 선언
+
+    @Mock
+    private ValueOperations<String, String> valueOperations; // ValueOperations을 Mock 객체로 선언
+
+    @InjectMocks
+    private RedisService redisService; // 테스트 대상 서비스
+
+    @BeforeEach
+    public void setUp() {
+        // Mockito 초기화
+        MockitoAnnotations.initMocks(this);
+
+        // opsForValue()를 Mock 객체로 설정
+        when(redisTemplate.opsForValue()).thenReturn(valueOperations);
+    }
+
+    @Test
+    public void testSaveValue() {
+        // Given: 테스트를 위한 값 설정
+        String key = "myKey";
+        String value = "myValue";
+
+        // When: saveValue 메서드 호출
+        redisService.saveValue(key, value);
+
+        // Then: RedisTemplate의 opsForValue().set() 메서드가 호출되었는지 검증
+        verify(valueOperations).set(key, value); // set() 메서드가 호출되었는지 검증
+        System.out.println("Redis Mock Test1 success");
+    }
+
+    @Test
+    public void testGetValue() {
+        // Given: RedisTemplate이 리턴할 값을 설정
+        String key = "myKey";
+        String expectedValue = "myValue";
+        when(valueOperations.get(key)).thenReturn(expectedValue); // mock 리턴 값 설정
+
+        // When: getValue 메서드 호출
+        String actualValue = redisService.getValue(key);
+
+        // Then: 값이 제대로 반환되는지 검증
+        assertEquals(expectedValue, actualValue); // 예상 값과 실제 값 비교
+        System.out.println("Redis Mock Test2 success");
+    }
+}

--- a/src/test/java/com/pawever/server/domain/cicd/service/RedisServiceTest.java
+++ b/src/test/java/com/pawever/server/domain/cicd/service/RedisServiceTest.java
@@ -1,60 +1,29 @@
 package com.pawever.server.domain.cicd.service;
 
-import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
-import org.mockito.InjectMocks;
-import org.mockito.Mock;
-import org.mockito.MockitoAnnotations;
-import org.springframework.data.redis.core.RedisTemplate;
-import org.springframework.data.redis.core.ValueOperations;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.context.SpringBootTest;
+import static org.assertj.core.api.Assertions.assertThat;
 
-import static org.junit.jupiter.api.Assertions.*;
-import static org.mockito.Mockito.verify;
-import static org.mockito.Mockito.when;
+@SpringBootTest
+public class RedisServiceTest {
+    // Mock 객체 없이 실제 Redis 테스트
 
-class RedisServiceTest {
-    @Mock
-    private RedisTemplate<String, String> redisTemplate; // RedisTemplate을 Mock 객체로 선언
-
-    @Mock
-    private ValueOperations<String, String> valueOperations; // ValueOperations을 Mock 객체로 선언
-
-    @InjectMocks
-    private RedisService redisService; // 테스트 대상 서비스
-
-    @BeforeEach
-    public void setUp() {
-        // Mockito 초기화
-        MockitoAnnotations.initMocks(this);
-
-        // opsForValue()를 Mock 객체로 설정
-        when(redisTemplate.opsForValue()).thenReturn(valueOperations);
-    }
+    @Autowired
+    private RedisService redisService;
 
     @Test
-    public void testSaveValue() {
-        // Given: 테스트를 위한 값 설정
-        String key = "myKey";
-        String value = "myValue";
+    public void testSaveAndGetValue() {
+        // given
+        String key = "testKey";
+        String value = "testValue";
 
-        // When: saveValue 메서드 호출
+        // when
         redisService.saveValue(key, value);
+        String retrievedValue = redisService.getValue(key);
 
-        // Then: RedisTemplate의 opsForValue().set() 메서드가 호출되었는지 검증
-        verify(valueOperations).set(key, value); // set() 메서드가 호출되었는지 검증
-    }
-
-    @Test
-    public void testGetValue() {
-        // Given: RedisTemplate이 리턴할 값을 설정
-        String key = "myKey";
-        String expectedValue = "myValue";
-        when(valueOperations.get(key)).thenReturn(expectedValue); // mock 리턴 값 설정
-
-        // When: getValue 메서드 호출
-        String actualValue = redisService.getValue(key);
-
-        // Then: 값이 제대로 반환되는지 검증
-        assertEquals(expectedValue, actualValue); // 예상 값과 실제 값 비교
+        // then
+        assertThat(retrievedValue).isEqualTo(value);
+        System.out.println("Redis Test without Mock success");
     }
 }

--- a/src/test/resources/application-test.yml
+++ b/src/test/resources/application-test.yml
@@ -12,7 +12,7 @@ spring:
       ddl-auto: none
     properties :
       hibernate:
-#        dialect: org.hibernate.dialect.H2Dialect
+        dialect: org.hibernate.dialect.H2Dialect
         format_sql: true
   sql:
     init:

--- a/src/test/resources/application-test.yml
+++ b/src/test/resources/application-test.yml
@@ -1,4 +1,10 @@
 spring:
+  config:
+    import: optional:file:.env[.properties]
+  data:
+    redis:
+      host: ${REDIS_HOST_NAME}
+      port: ${REDIS_PORT}
   jpa:
     database-platform: org.hibernate.dialect.H2Dialect #추가
     show-sql: true
@@ -20,5 +26,5 @@ spring:
     console:
       settings:
         web-allow-others: true
-      enbaled : true
-      path : /h2
+      enabled: true
+      path: /h2

--- a/src/test/resources/application-test.yml
+++ b/src/test/resources/application-test.yml
@@ -12,7 +12,7 @@ spring:
       ddl-auto: none
     properties :
       hibernate:
-        dialect: org.hibernate.dialect.H2Dialect
+#        dialect: org.hibernate.dialect.H2Dialect
         format_sql: true
   sql:
     init:


### PR DESCRIPTION
## #️⃣연관된 이슈

> ex) #10 

## 📝작업 내용

> 기존 코드로 CI환경에서 테스트 진행시 Datasource를 찾을 수 없다는 에러가 발생하였고, 분석한 결과 테스트 환경에서 application-test.yml 파일이 적용되지 않아서 발생한 문제임을 확인하였습니다.

> application.yml 에서 spring.profiles.active 값이 dev로 설정되어있어서 ./gradlew clean build -Dspring.profiles.active=test로 실행하여도 test profile을 적용하지 못하는 문제임을 발견하였고, 다음과 같이 active profile가 아닌 default profile 지정으로 변경하여 해결하였습니다.

![image](https://github.com/user-attachments/assets/d8641ebe-8889-4385-ab83-371bfbc3e618)


## 💬리뷰 요구사항(선택)

> 리뷰어가 특별히 봐주었으면 하는 부분이 있다면 작성해주세요
> 혹시 더 좋은 해결책이 있다면 커멘트 부탁드립니다.


## ✅ 체크리스트

- [x] PR 제목 규칙 잘 지켰는가?
- [x] 추가/수정사항을 설명하였는가?
- [x] 이슈넘버를 적었는가?
