### PR TITLE
feat : spring-app 컨테이너의 로그파일이 ec2(host) 경로로 복제될 수 있도록 Volume 세팅

### DIFF
--- a/compose.yml
+++ b/compose.yml
@@ -14,6 +14,7 @@ services:
     #추가
     volumes:
       - /home/ubuntu/compose/propertytransfer/:/app/settings/
+      - /home/ubuntu/compose/springlogs/:/app/logs/
   redis-server:
     image: redis
     container_name: paw-redis


### PR DESCRIPTION
## #️⃣연관된 이슈

> #34 

## 📝작업 내용
- 스프링 서버가 담긴 컨테이너가 오류로 종료될 경우 스프링 서버의 에러를 확인할 수 없어서 ec2로 log 파일을 복제해올 수 이도록 Volume 설정 추가했습니다.
- 스프링 서버의 로그는 ec2 다음 경로(/home/ubuntu/compose/springlogs)에서 확인할 수 있습니다.

## 💬리뷰 요구사항(선택)
- approve 부탁드립니다.



## ✅ 체크리스트

- [x] PR 제목 규칙 잘 지켰는가?
- [x] 추가/수정사항을 설명하였는가?
- [x] 이슈넘버를 적었는가?
