### PR TITLE
feat : redisconfig에 redis port를 설정해줘야하는 관계로  spring.data.port 정보 추가

### DIFF
--- a/src/main/resources/application-dev.yml
+++ b/src/main/resources/application-dev.yml
@@ -4,6 +4,7 @@ spring:
   data:
     redis:
       host: ${REDIS_HOST_NAME}
+      port: ${REDIS_PORT}
   datasource:
     driver-class-name: org.mariadb.jdbc.Driver
     url: ${DB_HOST}


### PR DESCRIPTION
## #️⃣연관된 이슈

> #37, #34, #28 

## 📝작업 내용
- #28 배포 이후 Redis Config 파일에서 Redis Port관련된 정보를 읽어오지 못하는 오류를 확인하였습니다.
- 해결을 위해 application-dev.yml에 spring.data.redis.port 정보 추가하였습니다.
- github secrets에 환경변수 등록하였습니다.

## 💬리뷰 요구사항(선택)
- approve 부탁드립니다.

## ✅ 체크리스트
- [x] PR 제목 규칙 잘 지켰는가?
- [x] 추가/수정사항을 설명하였는가?
- [x] 이슈넘버를 적었는가?
