### PR TITLE
fix : CI/CD 진행시 api 문서가 생성되지 않는 문제 해결

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -88,6 +88,10 @@ tasks.named('test') {
 //    }
 }
 
+tasks.named('asciidoctor') {
+    dependsOn tasks.named('test') // asciidoctor는 test 이후 실행
+}
+
 tasks.register('copyDocument', Copy){
     dependsOn tasks.named('asciidoctor')
     delete file('src/main/resources/static/docs/index.html')
@@ -95,6 +99,9 @@ tasks.register('copyDocument', Copy){
     into file("src/main/resources/static/docs")
 }
 
+tasks.named('build') {
+    dependsOn tasks.named('copyDocument') // build 실행 시 copyDocument까지 포함
+}
 
 openapi3 {
     servers = [


### PR DESCRIPTION
## #️⃣연관된 이슈
> #39 

## 📝작업 내용
- gradle build 과정에 test, ascillDoctor, copyDocumnet 순서로 태스크 진행되도록 설정하였습니다.
- local 환경에서 gradlew clean build 진행시 정상적으로 src/main/resources/static/docs에 index.html 생성되는 것 확인하였습니다.
- CI/CD환경에서 정상작동하는지 추가확인하겠습니다.

## 💬리뷰 요구사항(선택)
- comment 및 approve 부탁드립니다.

## ✅ 체크리스트
- [x] PR 제목 규칙 잘 지켰는가?
- [x] 추가/수정사항을 설명하였는가?
- [x] 이슈넘버를 적었는가?
