### PR TITLE
feat: gradle build 작업시 copyDocument 작업이 ProcessResources 작업에 선행하도록 조치

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -88,19 +88,11 @@ tasks.named('test') {
 //    }
 }
 
-tasks.named('asciidoctor') {
-    dependsOn tasks.named('test') // asciidoctor는 test 이후 실행
-}
-
 tasks.register('copyDocument', Copy){
     dependsOn tasks.named('asciidoctor')
     delete file('src/main/resources/static/docs/index.html')
     from file("build/docs/asciidoc")
     into file("src/main/resources/static/docs")
-}
-
-tasks.named('build') {
-    dependsOn tasks.named('copyDocument') // build 실행 시 copyDocument까지 포함
 }
 
 openapi3 {

--- a/build.gradle
+++ b/build.gradle
@@ -95,6 +95,14 @@ tasks.register('copyDocument', Copy){
     into file("src/main/resources/static/docs")
 }
 
+tasks.named('processResources') {
+    mustRunAfter tasks.named('copyDocument')
+}
+
+tasks.named('build') {
+    dependsOn tasks.named('copyDocument')
+}
+
 openapi3 {
     servers = [
             { url = "http://localhost:8080" }


### PR DESCRIPTION
## #️⃣연관된 이슈

> #39 

## 📝작업 내용
- 기본 build gradle 설정상 copyDocument Task가 ProcessResources Task(src/main/resources의 파일들을 build/resources로 복사하는 작업)보다 뒤에 진행되어 api 문서(index.html)이 jar파일에 포함되지 않는 문제가 있었습니다.
- 이를 해결하기 위해서 ProcessResources 태스크가 반드시 copyDocument 작업 이후에 진행되도록 조치했습니다.

## 💬리뷰 요구사항(선택)
- approve 부탁드립니다.

## ✅ 체크리스트
- [x] PR 제목 규칙 잘 지켰는가?
- [x] 추가/수정사항을 설명하였는가?
- [x] 이슈넘버를 적었는가?
