### PR TITLE
feat : ci/cd 절차상 asciidoctor를 통해 생성되는 api html 문서가 jar파일에 포함되도록 수정

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -16,6 +16,21 @@ java {
     }
 }
 
+ext {
+    snippetsDir = file('build/generated-snippets')
+}
+
+bootJar {
+    dependsOn asciidoctor
+//    copy {
+//        from "build/docs/asciidoc"
+//        into 'static/docs'
+//    }
+    from("${asciidoctor.outputDir}") {
+        into("BOOT-INF/classes/static/docs")
+    }
+}
+
 configurations {
     compileOnly {
         extendsFrom annotationProcessor
@@ -74,9 +89,14 @@ dependencies {
 
 }
 
-ext {
-    snippetsDir = file('build/generated-snippets')
+
+asciidoctor {
+    dependsOn test
+    inputs.dir snippetsDir
 }
+
+
+
 
 tasks.named('test') {
 //    delete file('build/generated-snippets')
@@ -88,19 +108,17 @@ tasks.named('test') {
 //    }
 }
 
+
 tasks.register('copyDocument', Copy){
     dependsOn tasks.named('asciidoctor')
     delete file('src/main/resources/static/docs/index.html')
     from file("build/docs/asciidoc")
     into file("src/main/resources/static/docs")
+//    into file("build/resources/main/static/docs")
 }
 
-tasks.named('processResources') {
-    mustRunAfter tasks.named('copyDocument')
-}
-
-tasks.named('build') {
-    dependsOn tasks.named('copyDocument')
+build {
+    dependsOn copyDocument
 }
 
 openapi3 {


### PR DESCRIPTION
## #️⃣연관된 이슈

> #39, #40  #41 

## 📝작업 내용
- ci/cd 절차상 asciidoctor 태스크를 통해 생성되는 api html 문서가 jar 파일에 포함되지 않는 문제를 해결하였습니다.
- bootJar 태스크 진행시 asciidoctor의 output 디렉토리 내용을 jar 파일의 resources 디렉토리로 포함시키도록 수정하였습니다.

## 💬리뷰 요구사항(선택)
- ci/cd 절차 수정 작업 특성상 우선 pr/push 예정이며, 작업 성공 여부에 따라 추가적인 수정이 필요할 수 있습니다.
- approve 부탁드립니다.

## ✅ 체크리스트
- [x] PR 제목 규칙 잘 지켰는가?
- [x] 추가/수정사항을 설명하였는가?
- [x] 이슈넘버를 적었는가?
