### PR TITLE
feat : Role 설정 보완후 토큰 재발급 기능 구현 및 테스트 진행

### DIFF
--- a/src/docs/asciidoc/index.adoc
+++ b/src/docs/asciidoc/index.adoc
@@ -118,3 +118,25 @@ include::build/generated-snippets/api/auth/login/success/http-response.adoc[]
 
 ==== 실패 Response
 include::build/generated-snippets/api/auth/login/failure-missing-fields/http-response.adoc[]
+
+=== **2. 토큰재발급 (POST /api/auth/refreshedtokens)**
+Request에 포함된 Refresh Token을 검증하고 새로운 Access Token 및 Refresh Token을 발급하는 API입니다. +
+
+==== Request
+include::build/generated-snippets/api/auth/refreshedtokens/success/curl-request.adoc[]
+
+==== 성공 Response
+include::build/generated-snippets/api/auth/refreshedtokens/success/http-response.adoc[]
+
+==== 실패 Response
+실패1. (Refresh Token 없음)
+include::build/generated-snippets/api/auth/refreshedtokens/failure-null/http-response.adoc[]
+
+실패2. (Refresh Token 만료됨)
+include::build/generated-snippets/api/auth/refreshedtokens/failure-expired/http-response.adoc[]
+
+실패3. (Access Token 전달됨)
+include::build/generated-snippets/api/auth/refreshedtokens/failure-mismatch/http-response.adoc[]
+
+실패4. (서버 저장소에 없는 Refresh Token)
+include::build/generated-snippets/api/auth/refreshedtokens/failure-stolen/http-response.adoc[]

--- a/src/main/java/com/pawever/server/common/response/ResponseCodeEnum.java
+++ b/src/main/java/com/pawever/server/common/response/ResponseCodeEnum.java
@@ -20,6 +20,11 @@ public enum ResponseCodeEnum {
     JWT_TOKEN_INVALID(HttpStatus.UNAUTHORIZED, "AUTH_1", "JWT 토큰이 유효하지 않습니다."),
     INSUFFICIENT_PERMISSIONS(HttpStatus.FORBIDDEN, "AUTH_2", "권한이 부족합니다."),
 
+    COOKIE_NULL(HttpStatus.BAD_REQUEST, "AUTH_3", "Cookie가 존재하지 않습니다."),
+    REFRESH_TOKEN_NULL(HttpStatus.BAD_REQUEST, "AUTH_4", "Refresh Token이 존재하지 않습니다."),
+    TOKEN_CATEGORY_MISMATCH(HttpStatus.BAD_REQUEST, "AUTH_5", "Token 카테고리가 Refresh와 일치하지 않습니다."),
+    REFRESH_TOKEN_NOT_FOUND(HttpStatus.UNAUTHORIZED, "AUTH_6", "서버에 존재하지 않는 Refresh Token입니다."),
+
     // 사용자 관련 에러
     USER_NOT_FOUND(HttpStatus.NOT_FOUND, "USER_0", "user 정보를 찾을 수 없음."),
 

--- a/src/main/java/com/pawever/server/domain/user/config/SecurityConfig.java
+++ b/src/main/java/com/pawever/server/domain/user/config/SecurityConfig.java
@@ -36,9 +36,9 @@ public class SecurityConfig {
         http
             .authorizeHttpRequests((auth) -> auth
                 .requestMatchers(HttpMethod.POST, "/api/auth/tokens").permitAll()  // 로그인 요청시 허용
-//                .requestMatchers("/**").permitAll()  // 로그인 기능 완전히 구현할때까지 우선 모두 허용
-                .requestMatchers("/api/auth/refreshedtokens").permitAll()  // 토큰 재발급 요청
-                .requestMatchers("/admin").hasRole("ADMIN")
+                .requestMatchers("/**").permitAll()  // 로그인 기능 완전히 구현할때까지 우선 모두 허용
+//                .requestMatchers("/api/auth/refreshedtokens").permitAll()  // 토큰 재발급 요청
+//                .requestMatchers("/admin").hasRole("ADMIN")
                 .anyRequest().authenticated()
             );
         //인증 실패 시 401 Unauthorized 응답을 반환

--- a/src/main/java/com/pawever/server/domain/user/config/SecurityConfig.java
+++ b/src/main/java/com/pawever/server/domain/user/config/SecurityConfig.java
@@ -36,7 +36,7 @@ public class SecurityConfig {
         http
             .authorizeHttpRequests((auth) -> auth
                 .requestMatchers(HttpMethod.POST, "/api/auth/tokens").permitAll()  // 로그인 요청시 허용
-                .requestMatchers("/**").permitAll()  // 로그인 기능 완전히 구현할때까지 우선 모두 허용
+//                .requestMatchers("/**").permitAll()  // 로그인 기능 완전히 구현할때까지 우선 모두 허용
                 .requestMatchers("/admin").hasRole("ADMIN")
                 .anyRequest().authenticated()
             );

--- a/src/main/java/com/pawever/server/domain/user/config/SecurityConfig.java
+++ b/src/main/java/com/pawever/server/domain/user/config/SecurityConfig.java
@@ -37,6 +37,7 @@ public class SecurityConfig {
             .authorizeHttpRequests((auth) -> auth
                 .requestMatchers(HttpMethod.POST, "/api/auth/tokens").permitAll()  // 로그인 요청시 허용
 //                .requestMatchers("/**").permitAll()  // 로그인 기능 완전히 구현할때까지 우선 모두 허용
+                .requestMatchers("/api/auth/refreshedtokens").permitAll()  // 토큰 재발급 요청
                 .requestMatchers("/admin").hasRole("ADMIN")
                 .anyRequest().authenticated()
             );

--- a/src/main/java/com/pawever/server/domain/user/controller/AuthController.java
+++ b/src/main/java/com/pawever/server/domain/user/controller/AuthController.java
@@ -4,6 +4,8 @@ import com.pawever.server.common.response.ApiResponse;
 import com.pawever.server.common.response.ResponseCodeEnum;
 import com.pawever.server.domain.user.dto.request.AuthRequestDto;
 import com.pawever.server.domain.user.service.AuthService;
+import jakarta.servlet.http.HttpServletRequest;
+import jakarta.servlet.http.HttpServletResponse;
 import lombok.RequiredArgsConstructor;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.PostMapping;
@@ -20,10 +22,16 @@ public class AuthController {
 
     @PostMapping("/tokens")
     public ResponseEntity<?> login(@RequestBody AuthRequestDto authRequestDto) {
-
         return ResponseEntity.status(ResponseCodeEnum.NO_CONTENT.getStatus())
             .headers(authService.login(authRequestDto))
             .build();
-
     }
+
+    @PostMapping("/refreshedtokens")
+    public ResponseEntity<?> refreshTokens(HttpServletRequest request) {
+        return ResponseEntity.status(ResponseCodeEnum.NO_CONTENT.getStatus())
+            .headers(authService.refreshTokens(request))
+            .build();
+    }
+
 }

--- a/src/main/java/com/pawever/server/domain/user/controller/UserController.java
+++ b/src/main/java/com/pawever/server/domain/user/controller/UserController.java
@@ -1,4 +1,36 @@
 package com.pawever.server.domain.user.controller;
 
+import com.pawever.server.domain.user.enums.Role;
+import com.pawever.server.domain.user.jwt.JwtUtil;
+import jakarta.servlet.http.HttpServletRequest;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.RestController;
+
+@RestController
+@Slf4j
 public class UserController {
+
+    @Autowired
+    JwtUtil jwtUtil;
+
+    @GetMapping("/admin")
+    public String admin(HttpServletRequest request) {
+        // admin 권한 확인용 테스트 컨트롤러입니다.
+
+        String accessTokenWithBearer= request.getHeader("Authorization");
+        log.info("accessTokenWithBearer: " + accessTokenWithBearer);
+
+        String accessToken = accessTokenWithBearer.split(" ")[1];
+        String category = jwtUtil.getCategory(accessToken);
+        String socialLoginUuid = jwtUtil.getSocialLoginUuid(accessToken);
+        Role role = jwtUtil.getRole(accessToken);
+
+        log.info("category: "+category);
+        log.info("socialLoginUuid: "+socialLoginUuid);
+        log.info("role: "+role.name());
+
+        return "admin authority confirmed";
+    }
 }

--- a/src/main/java/com/pawever/server/domain/user/dto/response/CustomUserDetails.java
+++ b/src/main/java/com/pawever/server/domain/user/dto/response/CustomUserDetails.java
@@ -3,8 +3,10 @@ package com.pawever.server.domain.user.dto.response;
 import com.pawever.server.domain.user.entity.jpa.User;
 import java.util.ArrayList;
 import java.util.Collection;
+import java.util.List;
 import org.springframework.security.core.GrantedAuthority;
 
+import org.springframework.security.core.authority.SimpleGrantedAuthority;
 import org.springframework.security.core.userdetails.UserDetails;
 
 public class CustomUserDetails implements UserDetails {
@@ -18,19 +20,7 @@ public class CustomUserDetails implements UserDetails {
 
     @Override
     public Collection<? extends GrantedAuthority> getAuthorities() {
-
-        Collection<GrantedAuthority> collection = new ArrayList<>();
-
-        collection.add(new GrantedAuthority() {
-
-            @Override
-            public String getAuthority() {
-
-                return userAuthInfoDto.getRole().name();
-            }
-        });
-
-        return collection;
+        return List.of(new SimpleGrantedAuthority(userAuthInfoDto.getRole().name()));
     }
 
     @Override

--- a/src/main/java/com/pawever/server/domain/user/jwt/JwtFilter.java
+++ b/src/main/java/com/pawever/server/domain/user/jwt/JwtFilter.java
@@ -38,9 +38,9 @@ public class JwtFilter extends OncePerRequestFilter {
             (method.equalsIgnoreCase("POST"));
         boolean isTokenRefreshRequest = path.equals("/api/auth/refreshedtokens") &&
             (method.equalsIgnoreCase("POST"));
-        // boolean allRequestAllowance = path.startsWith("/");  // 로그인 기능 완전히 구현할때까지 우선 모두 허용
-        // return isAuthTokenRequest || allRequestAllowance;
-        return isLoginRequest || isTokenRefreshRequest;
+         boolean allRequestAllowance = path.startsWith("/");  // 로그인 기능 완전히 구현할때까지 우선 모두 허용
+         return allRequestAllowance;
+//        return isLoginRequest || isTokenRefreshRequest;
     }
 
     // JWTUtil 클래스에 정의해두었던 Jwt토큰 검증에 사용되는 메서드들을 사용해야하므로

--- a/src/main/java/com/pawever/server/domain/user/jwt/JwtFilter.java
+++ b/src/main/java/com/pawever/server/domain/user/jwt/JwtFilter.java
@@ -34,8 +34,9 @@ public class JwtFilter extends OncePerRequestFilter {
         // 🔹 기존 인증 제외 조건: POST, PUT /api/auth/tokens
         boolean isAuthTokenRequest = path.equals("/api/auth/tokens") &&
             (method.equalsIgnoreCase("POST") || method.equalsIgnoreCase("PUT"));
-        boolean allRequestAllowance = path.startsWith("/");  // 로그인 기능 완전히 구현할때까지 우선 모두 허용
-        return isAuthTokenRequest || allRequestAllowance;
+//        boolean allRequestAllowance = path.startsWith("/");  // 로그인 기능 완전히 구현할때까지 우선 모두 허용
+//        return isAuthTokenRequest || allRequestAllowance;
+        return isAuthTokenRequest;
     }
 
     // JWTUtil 클래스에 정의해두었던 Jwt토큰 검증에 사용되는 메서드들을 사용해야하므로

--- a/src/main/java/com/pawever/server/domain/user/jwt/JwtFilter.java
+++ b/src/main/java/com/pawever/server/domain/user/jwt/JwtFilter.java
@@ -1,5 +1,7 @@
 package com.pawever.server.domain.user.jwt;
 
+import com.pawever.server.common.exception.CustomException;
+import com.pawever.server.common.response.ResponseCodeEnum;
 import com.pawever.server.domain.user.dto.response.CustomUserDetails;
 import com.pawever.server.domain.user.dto.response.UserAuthInfoDto;
 import com.pawever.server.domain.user.enums.Role;
@@ -32,11 +34,13 @@ public class JwtFilter extends OncePerRequestFilter {
         String method = request.getMethod();
 
         // 🔹 기존 인증 제외 조건: POST, PUT /api/auth/tokens
-        boolean isAuthTokenRequest = path.equals("/api/auth/tokens") &&
-            (method.equalsIgnoreCase("POST") || method.equalsIgnoreCase("PUT"));
-//        boolean allRequestAllowance = path.startsWith("/");  // 로그인 기능 완전히 구현할때까지 우선 모두 허용
-//        return isAuthTokenRequest || allRequestAllowance;
-        return isAuthTokenRequest;
+        boolean isLoginRequest = path.equals("/api/auth/tokens") &&
+            (method.equalsIgnoreCase("POST"));
+        boolean isTokenRefreshRequest = path.equals("/api/auth/refreshedtokens") &&
+            (method.equalsIgnoreCase("POST"));
+        // boolean allRequestAllowance = path.startsWith("/");  // 로그인 기능 완전히 구현할때까지 우선 모두 허용
+        // return isAuthTokenRequest || allRequestAllowance;
+        return isLoginRequest || isTokenRefreshRequest;
     }
 
     // JWTUtil 클래스에 정의해두었던 Jwt토큰 검증에 사용되는 메서드들을 사용해야하므로
@@ -60,14 +64,15 @@ public class JwtFilter extends OncePerRequestFilter {
         String accessToken = accessTokenWithBearer.split(" ")[1];
 
         // 3. 토큰이 있다면 토큰 만료 여부 확인, 만료시 다음 필터로 넘기지 않음
+        // todo 프론트 측과 만료시 반환하는 응답 코드 및 메세지 조율 필요(400 또는 401)
+        // 토큰 만료시 401(UNAUTHORIZED) 반환
         try {
             jwtUtil.isExpired(accessToken);
         } catch (ExpiredJwtException e) {
-            response.setStatus(HttpServletResponse.SC_UNAUTHORIZED);
-            response.getWriter().print("액세스 토큰이 만료되었습니다.");
             log.error("[JWTFilter] 액세스 토큰이 만료되었습니다.");
-            return;
+            throw new CustomException(ResponseCodeEnum.JWT_TOKEN_EXPIRED);
         }
+
 
         // 4. 토큰 category 가 access인지 확인 (발급시 페이로드에 명시)
         String category = jwtUtil.getCategory(accessToken);

--- a/src/main/java/com/pawever/server/domain/user/service/AuthService.java
+++ b/src/main/java/com/pawever/server/domain/user/service/AuthService.java
@@ -1,10 +1,17 @@
 package com.pawever.server.domain.user.service;
 
+import com.pawever.server.common.exception.CustomException;
+import com.pawever.server.common.response.ResponseCodeEnum;
 import com.pawever.server.domain.user.dto.request.AuthRequestDto;
 import com.pawever.server.domain.user.dto.response.UserResponseDto;
 import com.pawever.server.domain.user.jwt.JwtUtil;
 
+import io.jsonwebtoken.ExpiredJwtException;
+import jakarta.servlet.http.Cookie;
+import jakarta.servlet.http.HttpServletRequest;
+import jakarta.servlet.http.HttpServletResponse;
 import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
 import org.springframework.beans.factory.annotation.Value;
 import org.springframework.http.HttpHeaders;
 import org.springframework.stereotype.Service;
@@ -12,6 +19,7 @@ import org.springframework.transaction.annotation.Transactional;
 
 @Service
 @RequiredArgsConstructor
+@Slf4j
 public class AuthService {
 
     private final JwtUtil jwtUtil;
@@ -48,6 +56,50 @@ public class AuthService {
         return createHttpHeader(accessToken, refreshToken);
     }
 
+    public HttpHeaders refreshTokens(HttpServletRequest request){
+
+        String refreshToken = null;
+
+        // 1. request로부터 refreshToken 가져오기
+        // 쿠키나 Refresh 토큰이 없는 경우 400(BAD_REQUEST) 반환
+        refreshToken = getRefreshToken(request);
+
+        System.out.println("refreshToken: " + refreshToken);
+        // 2. refreshToken 만료 확인
+        // 토큰 만료시 401(UNAUTHORIZED) 반환
+        // todo 프론트 측과 만료시 반환하는 응답 코드 및 메세지 조율 필요(400 또는 401)
+        try {
+            jwtUtil.isExpired(refreshToken);
+        } catch (ExpiredJwtException e) {
+            log.error("[JWTFilter] 리프레시 토큰이 만료되었습니다.");
+            throw new CustomException(ResponseCodeEnum.JWT_TOKEN_EXPIRED);
+        }
+
+        // 3. 토큰 구분 확인(access or refresh)
+        // Refresh 토큰이 아닌경우 400(BAD_REQUEST) 반환
+        checkTokenCategory(refreshToken);
+
+        // 4. redis 서버에 존재하는 refresh토큰인지 확인(Refresh Rotate)
+        // 존재하지 않는 refresh 토큰이라면 탈취된 토큰으로 간주하고 401(UNAUTHORIZED) 반환
+        refreshTokenService.getRefreshToken(refreshToken);
+
+        // 5. Refresh토큰의 사용자 정보 추출
+        UserResponseDto userResponseDto = jwtUtil.getUserResponseDto(refreshToken);
+
+        // 6. AccessToken, RefreshToken 재발급(Refresh Rotate)
+        String accessToken = jwtUtil.createJwt("access", userResponseDto, accessTokenExpiredMs);
+        String newRefreshToken = jwtUtil.createJwt("refresh", userResponseDto, refreshTokenExpiredMs);
+
+        // 7. redis에 갱신된 RefreshToken 저장
+        // 1) 기존 RefreshToken 제거
+        refreshTokenService.removeRefreshToken(refreshToken);
+        // 2) 새로운 RefreshToken 저장
+        refreshTokenService.saveRefreshToken(newRefreshToken, userResponseDto.getName());
+
+        // 8. 컨트롤러로 반환
+        return createHttpHeader(accessToken, newRefreshToken);
+    }
+
 
     private HttpHeaders createHttpHeader(String accessToken, String refreshToken) {
         HttpHeaders httpHeaders = new HttpHeaders();
@@ -57,9 +109,38 @@ public class AuthService {
     }
 
     private String createCookieHeader(String name, String value) {
-        return name + "=" + value + "; HttpOnly; Max-Age=" + (60 * 5);
+        return name + "=" + value + "; HttpOnly; Max-Age=" + (refreshTokenExpiredMs);
 
         // https 설정
-//        return name + "=" + value + "; Path=/; HttpOnly; Secure;  Max-Age=" + (60 * 5);
+//        return name + "=" + value + "; Path=/; HttpOnly; Secure;  Max-Age=" + (refreshTokenExpiredMs);
     }
+
+    private String getRefreshToken(HttpServletRequest request) {
+
+        Cookie[] cookies = request.getCookies();
+
+        if(cookies == null){
+            // 쿠키가 존재하지 않는 경우 - 400(BAD REQUEST) 반환
+            // 400 반환받으면 프론트에서는 재로그인 진행
+            throw new CustomException(ResponseCodeEnum.COOKIE_NULL);
+        }
+
+        // 1. 쿠키에 저장된 Refresh Token 값을 가져오기
+        for(Cookie cookie : cookies){
+            if(cookie.getName().equals("refresh")){
+                return cookie.getValue();
+            }
+        }
+
+        // 2. Refresh Token이 없는 경우 - 400(BAD REQUEST) 반환
+        throw new CustomException(ResponseCodeEnum.REFRESH_TOKEN_NULL);
+    }
+
+    private void checkTokenCategory(String token){
+        if(!jwtUtil.getCategory(token).equals("refresh")){
+            // 400 코드 반환
+            throw new CustomException(ResponseCodeEnum.TOKEN_CATEGORY_MISMATCH);
+        }
+    }
+
 }

--- a/src/main/java/com/pawever/server/domain/user/service/RefreshTokenService.java
+++ b/src/main/java/com/pawever/server/domain/user/service/RefreshTokenService.java
@@ -36,4 +36,9 @@ public class RefreshTokenService {
         refreshTokenRepository.findRefreshTokenByRefreshToken(refreshToken)
             .ifPresent(token -> refreshTokenRepository.delete(token));
     }
+
+    public RefreshToken getRefreshToken(String refreshToken) {
+        return refreshTokenRepository.findRefreshTokenByRefreshToken(refreshToken)
+            .orElseThrow(()-> new CustomException(ResponseCodeEnum.REFRESH_TOKEN_NOT_FOUND));
+    }
 }

--- a/src/test/java/com/pawever/server/domain/user/controller/LoginIntegrationTest.java
+++ b/src/test/java/com/pawever/server/domain/user/controller/LoginIntegrationTest.java
@@ -133,7 +133,7 @@ class LoginIntegrationTest {
                     .summary("사용자 로그인 API")
                     .description(
                         "프론트에서 소셜 로그인 후 전달하는 유저 정보를 받아 AccessToken과 RefreshToken을 반환하는 API.\n\n" +
-                            (isSuccess ? "성공 시 응답 본문이 없고, 204 No Content를 반환합니다." :
+                            (isSuccess ? "성공 시 응답 본문이 없고, 204 No Content를 반환합니다.(헤더를 통해 토큰 전달)" :
                                 "실패 시 예외코드와 응답 본문을 반환합니다.")
                     )
                     .responseFields(isSuccess ? Collections.emptyList() : responseFieldDescriptorsForFailure) // 실패 시만 응답 필드 추가

--- a/src/test/java/com/pawever/server/domain/user/controller/RefreshTokenIntegrationTest.java
+++ b/src/test/java/com/pawever/server/domain/user/controller/RefreshTokenIntegrationTest.java
@@ -1,0 +1,281 @@
+package com.pawever.server.domain.user.controller;
+
+
+import static com.epages.restdocs.apispec.ResourceDocumentation.resource;
+import static org.springframework.restdocs.cookies.CookieDocumentation.cookieWithName;
+import static org.springframework.restdocs.cookies.CookieDocumentation.responseCookies;
+import static org.springframework.restdocs.headers.HeaderDocumentation.headerWithName;
+import static org.springframework.restdocs.headers.HeaderDocumentation.responseHeaders;
+import static org.springframework.restdocs.mockmvc.MockMvcRestDocumentation.document;
+import static org.springframework.restdocs.mockmvc.MockMvcRestDocumentation.documentationConfiguration;
+import static org.springframework.restdocs.operation.preprocess.Preprocessors.modifyHeaders;
+import static org.springframework.restdocs.operation.preprocess.Preprocessors.modifyUris;
+import static org.springframework.restdocs.operation.preprocess.Preprocessors.preprocessRequest;
+import static org.springframework.restdocs.operation.preprocess.Preprocessors.preprocessResponse;
+import static org.springframework.restdocs.operation.preprocess.Preprocessors.prettyPrint;
+import static org.springframework.restdocs.payload.PayloadDocumentation.fieldWithPath;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.content;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.cookie;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.header;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.jsonPath;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
+
+import com.epages.restdocs.apispec.ResourceSnippetParameters;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.pawever.server.PawEverApplication;
+import com.pawever.server.common.response.ResponseCodeEnum;
+import com.pawever.server.domain.user.dto.response.UserResponseDto;
+import com.pawever.server.domain.user.enums.Role;
+import com.pawever.server.domain.user.jwt.JwtUtil;
+import com.pawever.server.domain.user.service.RefreshTokenService;
+import jakarta.servlet.http.Cookie;
+import java.util.Collections;
+import java.util.List;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.autoconfigure.restdocs.AutoConfigureRestDocs;
+import org.springframework.boot.test.autoconfigure.web.servlet.AutoConfigureMockMvc;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.http.HttpHeaders;
+import org.springframework.http.MediaType;
+import org.springframework.restdocs.RestDocumentationContextProvider;
+import org.springframework.restdocs.RestDocumentationExtension;
+import org.springframework.restdocs.mockmvc.RestDocumentationRequestBuilders;
+import org.springframework.restdocs.mockmvc.RestDocumentationResultHandler;
+import org.springframework.restdocs.operation.preprocess.HeadersModifyingOperationPreprocessor;
+import org.springframework.restdocs.payload.FieldDescriptor;
+import org.springframework.restdocs.payload.JsonFieldType;
+import org.springframework.security.test.web.servlet.setup.SecurityMockMvcConfigurers;
+import org.springframework.test.context.ActiveProfiles;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.test.web.servlet.MockMvc;
+import org.springframework.test.web.servlet.ResultActions;
+import org.springframework.test.web.servlet.setup.MockMvcBuilders;
+import org.springframework.transaction.annotation.Transactional;
+import org.springframework.web.context.WebApplicationContext;
+
+@Slf4j
+@AutoConfigureMockMvc
+@AutoConfigureRestDocs
+@SpringBootTest(classes = {PawEverApplication.class})
+@ActiveProfiles("test")
+@ExtendWith({RestDocumentationExtension.class})
+class RefreshTokenIntegrationTest {
+
+    @Autowired
+    private MockMvc mockMvc;
+
+    private final ObjectMapper mapper = new ObjectMapper();
+
+    @Autowired
+    private JwtUtil jwtUtil;
+
+    @Autowired
+    private RefreshTokenService refreshTokenService;
+
+    @BeforeEach
+    void setup(WebApplicationContext context, RestDocumentationContextProvider restDocumentation) {
+        this.mockMvc = MockMvcBuilders
+            .webAppContextSetup(context)
+            .apply(SecurityMockMvcConfigurers.springSecurity()) // Spring Security 적용
+            .apply(documentationConfiguration(restDocumentation))
+            .build();
+    }
+
+    private HeadersModifyingOperationPreprocessor getModifiedHeader() {
+        return modifyHeaders().remove("X-Content-Type-Options")
+            .remove("X-XSS-Protection")
+            .remove("Cache-Control")
+            .remove("Pragma")
+            .remove("Expires")
+            .remove("Content-Length");
+    }
+
+    // 응답 필드 설명(Refresh Token 갱신 실패 시)
+    private final List<FieldDescriptor> responseFieldDescriptorsForFailure = List.of(
+        fieldWithPath("isSuccess").type(JsonFieldType.BOOLEAN).description("요청 성공 여부 (false)"),
+        fieldWithPath("status").type(JsonFieldType.STRING).description("HTTP 상태 코드"),
+        fieldWithPath("code").type(JsonFieldType.STRING).description("응답 에러 코드"),
+        fieldWithPath("data").type(JsonFieldType.OBJECT).optional().description("에러 발생 시 추가 데이터")
+    );
+
+    private ResultActions getResultActionsForRefreshToken(String refreshToken) throws Exception {
+        return mockMvc.perform(
+            RestDocumentationRequestBuilders
+                .post("/api/auth/refreshedtokens")
+                .cookie(new Cookie("refresh", refreshToken)) // Refresh Token 쿠키 추가
+                .contentType(MediaType.APPLICATION_JSON)
+        );
+    }
+
+    private ResultActions getResultActionsForRefreshToken() throws Exception {
+        return mockMvc.perform(
+            RestDocumentationRequestBuilders
+                .post("/api/auth/refreshedtokens") // 쿠키 없이 요청
+                .cookie(new Cookie("object", "object"))
+                .contentType(MediaType.APPLICATION_JSON)
+        );
+    }
+
+    private RestDocumentationResultHandler getDocumentForRefreshToken(String identifier, boolean isSuccess) {
+        return document(
+            "api/auth/refreshedtokens/" + identifier,
+            preprocessRequest(prettyPrint(), modifyUris().scheme("https").host("yellowdog.p-e.kr").removePort()),
+            preprocessResponse(prettyPrint(), getModifiedHeader()),
+            responseHeaders(
+                headerWithName(HttpHeaders.AUTHORIZATION).description("Bearer: New Access Token").optional()
+            ),
+            responseCookies(
+                cookieWithName("refresh").description("New Refresh Token (HttpOnly)").optional()
+            ),
+            resource(
+                ResourceSnippetParameters.builder()
+                    .tag("인증-auth")
+                    .summary("Jwt Token 갱신 API")
+                    .description(
+                        "기존 Refresh Token을 사용하여 새로운 Access Token과 Refresh Token을 발급하는 API.\n\n" +
+                            (isSuccess ? "성공 시 응답 본문이 없고, 204 No Content를 반환합니다.(헤더를 통해 토큰 전달)" :
+                                "실패 시 예외 코드와 응답 본문을 반환합니다.")
+                    )
+                    .responseFields(isSuccess ? Collections.emptyList() : responseFieldDescriptorsForFailure)
+                    .build())
+        );
+    }
+
+    // Refresh Token 갱신 성공 테스트
+    @Test
+    @Transactional
+    void refreshTokenSuccessTest() throws Exception {
+        // Given
+        // 1. 테스트용 refresh토큰 생성
+        UserResponseDto userResponseDto = UserResponseDto.builder()
+            .userId(100)
+            .socialLoginUuid("800a8d7a-442d-4f5b-967e-2ed138f6e789")
+            .name("TokenRefreshTester")
+            .role(Role.ROLE_USER)
+            .build();
+
+        String testRefreshToken = jwtUtil.createJwt("refresh", userResponseDto, 1000L * 60 * 60 * 24); // 24시간 유지
+
+        // 2. 생성된 refresh 토큰을 서버 redis에 저장
+        refreshTokenService.saveRefreshToken(testRefreshToken, userResponseDto.getName());
+
+        // When
+        ResultActions resultActions = getResultActionsForRefreshToken(testRefreshToken);
+
+        // Then
+        resultActions.andExpect(status().isNoContent()) // 204 응답 확인
+            .andExpect(content().string("")) // Response Body 없음 확인
+            .andExpect(header().exists(HttpHeaders.AUTHORIZATION)) // 새로운 Access Token 존재 확인
+            .andExpect(cookie().exists("refresh")); // 새로운 Refresh Token 존재 여부 확인
+
+        // Documentation
+        resultActions.andDo(getDocumentForRefreshToken("success", true));
+    }
+
+    // Refresh Token 갱신 실패 테스트 - 리프레시토큰이 없는 경우 (400)
+    @Test
+    @Transactional
+    void refreshTokenFailureTestNullToken() throws Exception {
+        // When
+        ResultActions resultActions = getResultActionsForRefreshToken();
+
+        // Then
+        resultActions.andExpect(status().isBadRequest()) // 400 응답 확인
+            .andExpect(jsonPath("isSuccess").value(false))
+            .andExpect(jsonPath("status").value(ResponseCodeEnum.REFRESH_TOKEN_NULL.getStatus().name()))
+            .andExpect(jsonPath("code").value(ResponseCodeEnum.REFRESH_TOKEN_NULL.getCode()));
+
+        // Documentation
+        resultActions.andDo(getDocumentForRefreshToken("failure-null", false));
+    }
+
+
+    // Refresh Token 갱신 실패 테스트 - 만료된 토큰 (401)
+    @Test
+    @Transactional
+    void refreshTokenFailureTestExpiredToken() throws Exception {
+        // Given
+        UserResponseDto userResponseDto = UserResponseDto.builder()
+            .userId(50)
+            .socialLoginUuid("900a8d7a-442d-4f5b-967e-2ed138f6e456")
+            .name("EXPIREDTokenRefreshTester")
+            .role(Role.ROLE_ADMIN)
+            .build();
+
+        String expiredTestRefreshToken = jwtUtil.createJwt("refresh", userResponseDto, 0L); // 만료된 토큰 생성
+
+        // When
+        ResultActions resultActions = getResultActionsForRefreshToken(expiredTestRefreshToken);
+
+        // Then
+        resultActions.andExpect(status().isUnauthorized()) // 401 응답 확인
+            .andExpect(jsonPath("isSuccess").value(false))
+            .andExpect(jsonPath("status").value(ResponseCodeEnum.JWT_TOKEN_EXPIRED.getStatus().name()))
+            .andExpect(jsonPath("code").value(ResponseCodeEnum.JWT_TOKEN_EXPIRED.getCode()));
+
+        // Documentation
+        resultActions.andDo(getDocumentForRefreshToken("failure-expired", false));
+    }
+
+    // Refresh Token 갱신 실패 테스트 - accesstoken을 보낸 경우(400)
+    @Test
+    @Transactional
+    void refreshTokenFailureTestCategoryMismatch() throws Exception {
+        // Given
+        // 토큰 생성후 서버 Redis에 넣지 않음
+        UserResponseDto userResponseDto = UserResponseDto.builder()
+            .userId(35)
+            .socialLoginUuid("445a8d7a-442d-4f5b-967e-2ed138f6e542")
+            .name("MismatchTokenRefreshTester")
+            .role(Role.ROLE_STAFF)
+            .build();
+
+        // access 토큰 생성해서 request에 담아 보냄
+        String categoryMistmatchTestRefreshToken = jwtUtil.createJwt("access", userResponseDto,
+            1000L * 60 * 60 * 24);
+
+        // When
+        ResultActions resultActions = getResultActionsForRefreshToken(categoryMistmatchTestRefreshToken);
+
+        // Then
+        resultActions.andExpect(status().isBadRequest()) // 400 응답 확인
+            .andExpect(jsonPath("isSuccess").value(false))
+            .andExpect(jsonPath("status").value(
+                ResponseCodeEnum.TOKEN_CATEGORY_MISMATCH.getStatus().name()))
+            .andExpect(jsonPath("code").value(ResponseCodeEnum.TOKEN_CATEGORY_MISMATCH.getCode()));
+
+        // Documentation
+        resultActions.andDo(getDocumentForRefreshToken("failure-mismatch", false));
+    }
+
+    // Refresh Token 갱신 실패 테스트 - 서버에 없는 토큰 (403)
+    @Test
+    @Transactional
+    void refreshTokenFailureTestStolenToken() throws Exception {
+        // Given
+        // 토큰 생성후 서버 Redis에 넣지 않음
+        UserResponseDto userResponseDto = UserResponseDto.builder()
+            .userId(75)
+            .socialLoginUuid("300a8d7a-442d-4f5b-967e-2ed138f6e333")
+            .name("StolenTokenRefreshTester")
+            .role(Role.ROLE_STAFF)
+            .build();
+
+        String stolenTestRefreshToken = jwtUtil.createJwt("refresh", userResponseDto, 1000L * 60 * 60 * 24); // 만료된 토큰 생성
+
+        // When
+        ResultActions resultActions = getResultActionsForRefreshToken(stolenTestRefreshToken);
+
+        // Then
+        resultActions.andExpect(status().isUnauthorized()) // 401 응답 확인
+            .andExpect(jsonPath("isSuccess").value(false))
+            .andExpect(jsonPath("status").value(ResponseCodeEnum.REFRESH_TOKEN_NOT_FOUND.getStatus().name()))
+            .andExpect(jsonPath("code").value(ResponseCodeEnum.REFRESH_TOKEN_NOT_FOUND.getCode()));
+
+        // Documentation
+        resultActions.andDo(getDocumentForRefreshToken("failure-stolen", false));
+    }
+}


### PR DESCRIPTION
## #️⃣연관된 이슈
- #43 

## 📝작업 내용
- 현재 Role Enum 클래스에 등록한 ROLE_USER, ROLE_ADMIN, ROLE_STAFF 를 Spring Security에서 읽어올 수 있도록 처리하였습니다.(ADMIN 권한 설정된 api 요청에 대해서 ROLE_ADMIN 권한 유저만 접근 가능함을 테스트 완료)
- Request에 포함된 Refresh Token을 검증한 뒤 Access Token 및 Refresh Token을 재발급하는 api를 구현하였습니다.
- 토큰 재발급 api 통합테스트를 작성하여, Refresh 토큰이 Request에 포함되지 않은 경우, 토큰이 만료된 경우, 토큰이 서버 저장소에 없는 경우 등 다양한 실패 경우에 대해 테스트를 진행하였습니다.

## 💬리뷰 요구사항(선택)
- 토큰 재발급시 발생 가능한 예외에 대해서 Refresh 토큰이 Request에 포함되지 않은 경우, 토큰이 만료된 경우, 토큰이 서버 저장소에 없는 경우, AccessToken을 보낸 경우를 처리하였는데, 그 외 추가적인 edge case가 있다면 의견 부탁드립니다.

## ✅ 체크리스트
- [x] PR 제목 규칙 잘 지켰는가?
- [x] 추가/수정사항을 설명하였는가?
- [x] 이슈넘버를 적었는가?
