### PR TITLE
feat : 일반 api 호출시 request에 담긴 accesstoken으로부터 SocialLoginUuid를 추출할 수 있는 메서드 구현

### DIFF
--- a/src/main/java/com/pawever/server/domain/user/config/SecurityConfig.java
+++ b/src/main/java/com/pawever/server/domain/user/config/SecurityConfig.java
@@ -4,6 +4,7 @@ import com.pawever.server.domain.user.handler.FilterExceptionHandler;
 import com.pawever.server.domain.user.jwt.CustomLogoutFilter;
 import com.pawever.server.domain.user.jwt.JwtFilter;
 import com.pawever.server.domain.user.jwt.JwtUtil;
+import com.pawever.server.domain.user.service.AccessTokenService;
 import com.pawever.server.domain.user.service.RefreshTokenService;
 import com.pawever.server.domain.user.service.UserService;
 import jakarta.servlet.http.HttpServletResponse;
@@ -29,6 +30,7 @@ public class SecurityConfig {
     private final JwtUtil jwtUtil;
     private final RefreshTokenService refreshTokenService;
     private final UserService userService;
+    private final AccessTokenService accessTokenService;
 
     @Bean
     public SecurityFilterChain filterChain(HttpSecurity http) throws Exception {
@@ -62,7 +64,7 @@ public class SecurityConfig {
                 .sessionCreationPolicy(SessionCreationPolicy.STATELESS));
 
         http
-            .addFilterBefore(new JwtFilter(jwtUtil), UsernamePasswordAuthenticationFilter.class);
+            .addFilterBefore(new JwtFilter(jwtUtil, accessTokenService), UsernamePasswordAuthenticationFilter.class);
         http
             .addFilterAt(new CustomLogoutFilter(jwtUtil, refreshTokenService, userService), LogoutFilter.class);
         http

--- a/src/main/java/com/pawever/server/domain/user/jwt/JwtFilter.java
+++ b/src/main/java/com/pawever/server/domain/user/jwt/JwtFilter.java
@@ -5,12 +5,15 @@ import com.pawever.server.common.response.ResponseCodeEnum;
 import com.pawever.server.domain.user.dto.response.CustomUserDetails;
 import com.pawever.server.domain.user.dto.response.UserAuthInfoDto;
 import com.pawever.server.domain.user.enums.Role;
+import com.pawever.server.domain.user.service.AccessTokenService;
+import com.pawever.server.domain.user.service.UserService;
 import io.jsonwebtoken.ExpiredJwtException;
 import jakarta.servlet.FilterChain;
 import jakarta.servlet.ServletException;
 import jakarta.servlet.http.HttpServletRequest;
 import jakarta.servlet.http.HttpServletResponse;
 import java.io.IOException;
+import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.security.authentication.UsernamePasswordAuthenticationToken;
 import org.springframework.security.core.Authentication;
@@ -18,14 +21,11 @@ import org.springframework.security.core.context.SecurityContextHolder;
 import org.springframework.web.filter.OncePerRequestFilter;
 
 @Slf4j
+@RequiredArgsConstructor
 public class JwtFilter extends OncePerRequestFilter {
 
     private final JwtUtil jwtUtil;
-
-    public JwtFilter(JwtUtil jwtUtil) {
-
-        this.jwtUtil = jwtUtil;
-    }
+    private final AccessTokenService accessTokenService;
 
     // Jwt 검증이 필요없는 요청들은 filter 적용 제외
     @Override
@@ -48,42 +48,48 @@ public class JwtFilter extends OncePerRequestFilter {
     @Override
     protected void doFilterInternal(HttpServletRequest request, HttpServletResponse response, FilterChain filterChain) throws ServletException, IOException {
 
-        // 1. AccessToken 꺼내기
-        String accessTokenWithBearer= request.getHeader("Authorization");
-        System.out.println("accessTokenWithBearer: " + accessTokenWithBearer);
+//        // 1. AccessToken 꺼내기
+//        String accessTokenWithBearer= request.getHeader("Authorization");
+//        System.out.println("accessTokenWithBearer: " + accessTokenWithBearer);
+//
+//        // 2. 토큰이 없다면 400(BAD_REQUEST) 발생시키고 필터 종료
+//        if (accessTokenWithBearer == null || !accessTokenWithBearer.startsWith("Bearer ")) {
+//            log.error("[JWTFilter] 액세스 토큰이 없습니다.");
+//            throw new CustomException(ResponseCodeEnum.ACCESS_TOKEN_NULL);
+//        }
+//
+//        // 2-1. 토큰에서 Bearer 제거하고 실질적인 토큰값을 가져오기
+//        String accessToken = accessTokenWithBearer.split(" ")[1];
+//
+//        // 3. 토큰이 있다면 토큰 만료 여부 확인, 만료시 다음 필터로 넘기지 않음
+//        // todo 프론트 측과 만료시 반환하는 응답 코드 및 메세지 조율 필요(400 또는 401)
+//        // 토큰 만료시 401(UNAUTHORIZED) 반환
+//        try {
+//            jwtUtil.isExpired(accessToken);
+//        } catch (ExpiredJwtException e) {
+//            log.error("[JWTFilter] 액세스 토큰이 만료되었습니다.");
+//            throw new CustomException(ResponseCodeEnum.JWT_TOKEN_EXPIRED);
+//        }
+//
+//        // 4. 토큰 category 가 access인지 확인
+//        // Refresh 토큰이 주어진 경우 BAD_REQUEST(400) 반환
+//        String category = jwtUtil.getCategory(accessToken);
+//        if (!category.equals("access")) {
+//            log.error("[JWTFilter] 액세스 토큰 타입이 아닙니다.");
+//            throw new CustomException(ResponseCodeEnum.TOKEN_CATEGORY_MISMATCH);
+//        }
+        // 1. 유효한 AccessToken 가져오기
+        String validAccessToken = accessTokenService.getValidRequestAccessToken(request);
 
-        // 2. 토큰이 없다면 400(BAD_REQUEST) 발생시키고 필터 종료
-        if (accessTokenWithBearer == null || !accessTokenWithBearer.startsWith("Bearer ")) {
-            log.error("[JWTFilter] 액세스 토큰이 없습니다.");
-            throw new CustomException(ResponseCodeEnum.ACCESS_TOKEN_NULL);
-        }
+        // 2. accesstoken에 대한 검증이 완료되었으므로 accesstoken에서 socialLoginUuid, role 값을 가져오기
+        String socialLoginUuid = jwtUtil.getSocialLoginUuid(validAccessToken);
+        Role role = jwtUtil.getRole(validAccessToken);
 
-        // 2-1. 토큰에서 Bearer 제거하고 실질적인 토큰값을 가져오기
-        String accessToken = accessTokenWithBearer.split(" ")[1];
+//        // 3. api에서 sociluuid 가져오는 것 테스트
+//        System.out.println("test get uuid from request : " + accessTokenService.getRequestSocialLoginUuid(request));
 
-        // 3. 토큰이 있다면 토큰 만료 여부 확인, 만료시 다음 필터로 넘기지 않음
-        // todo 프론트 측과 만료시 반환하는 응답 코드 및 메세지 조율 필요(400 또는 401)
-        // 토큰 만료시 401(UNAUTHORIZED) 반환
-        try {
-            jwtUtil.isExpired(accessToken);
-        } catch (ExpiredJwtException e) {
-            log.error("[JWTFilter] 액세스 토큰이 만료되었습니다.");
-            throw new CustomException(ResponseCodeEnum.JWT_TOKEN_EXPIRED);
-        }
 
-        // 4. 토큰 category 가 access인지 확인
-        // Refresh 토큰이 주어진 경우 BAD_REQUEST(400) 반환
-        String category = jwtUtil.getCategory(accessToken);
-        if (!category.equals("access")) {
-            log.error("[JWTFilter] 액세스 토큰 타입이 아닙니다.");
-            throw new CustomException(ResponseCodeEnum.TOKEN_CATEGORY_MISMATCH);
-        }
-
-        // 5. accesstoken에 대한 검증이 완료되었으므로 accesstoken에서 socialLoginUuid, role 값을 가져오기
-        String socialLoginUuid = jwtUtil.getSocialLoginUuid(accessToken);
-        Role role = jwtUtil.getRole(accessToken);
-
-        //6. UserAuthInfoDto에 name과 role을 넣어주고 CustomUserDetails에 담고
+        // 3. UserAuthInfoDto에 name과 role을 넣어주고 CustomUserDetails에 담고
         CustomUserDetails customUserDetails = new CustomUserDetails(
             UserAuthInfoDto.builder()
                 .socialLoginUuid(socialLoginUuid)
@@ -91,7 +97,7 @@ public class JwtFilter extends OncePerRequestFilter {
                 .build()
         );
 
-        // 7. Spring Security 인증 토큰 생성
+        // 4. Spring Security 인증 토큰 생성
         Authentication authToken = new UsernamePasswordAuthenticationToken(customUserDetails, null, customUserDetails.getAuthorities());
         SecurityContextHolder.getContext().setAuthentication(authToken);
 

--- a/src/main/java/com/pawever/server/domain/user/service/AccessTokenService.java
+++ b/src/main/java/com/pawever/server/domain/user/service/AccessTokenService.java
@@ -1,0 +1,82 @@
+package com.pawever.server.domain.user.service;
+
+
+import com.pawever.server.common.exception.CustomException;
+import com.pawever.server.common.response.ResponseCodeEnum;
+import com.pawever.server.domain.user.jwt.JwtUtil;
+import io.jsonwebtoken.ExpiredJwtException;
+import jakarta.servlet.http.Cookie;
+import jakarta.servlet.http.HttpServletRequest;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+@Service
+@Slf4j
+@RequiredArgsConstructor
+public class AccessTokenService {
+
+    private final JwtUtil jwtUtil;
+
+    public String getValidRequestAccessToken(HttpServletRequest request) {
+
+        // jwt 필터에서 검증할때 사용
+        // 1. AccessToken 꺼내기
+        String accessTokenWithBearer= request.getHeader("Authorization");
+        System.out.println("accessTokenWithBearer: " + accessTokenWithBearer);
+
+        // 2. 토큰이 없다면 400(BAD_REQUEST) 발생시키고 필터 종료
+        if (accessTokenWithBearer == null || !accessTokenWithBearer.startsWith("Bearer ")) {
+            log.error("[JWTFilter] 액세스 토큰이 없습니다.");
+            throw new CustomException(ResponseCodeEnum.ACCESS_TOKEN_NULL);
+        }
+
+        // 2-1. 토큰에서 Bearer 제거하고 실질적인 토큰값을 가져오기
+        String accessToken = accessTokenWithBearer.split(" ")[1];
+
+        // 3. 토큰이 있다면 토큰 만료 여부 확인, 만료시 다음 필터로 넘기지 않음
+        // todo 프론트 측과 만료시 반환하는 응답 코드 및 메세지 조율 필요(400 또는 401)
+        // 토큰 만료시 401(UNAUTHORIZED) 반환
+        try {
+            jwtUtil.isExpired(accessToken);
+        } catch (ExpiredJwtException e) {
+            log.error("[JWTFilter] 액세스 토큰이 만료되었습니다.");
+            throw new CustomException(ResponseCodeEnum.JWT_TOKEN_EXPIRED);
+        }
+
+        // 4. 토큰 category 가 access인지 확인
+        // Refresh 토큰이 주어진 경우 BAD_REQUEST(400) 반환
+        String category = jwtUtil.getCategory(accessToken);
+        if (!category.equals("access")) {
+            log.error("[JWTFilter] 액세스 토큰 타입이 아닙니다.");
+            throw new CustomException(ResponseCodeEnum.TOKEN_CATEGORY_MISMATCH);
+        }
+        return accessToken;
+    }
+
+    public String getRequestAccessToken(HttpServletRequest request) {
+        // 로그인 성공후 api에서 acceessToken내 정보 추출시 사용
+        // 1. AccessToken 꺼내기
+        String accessTokenWithBearer= request.getHeader("Authorization");
+
+        // 2. 토큰이 없다면 400(BAD_REQUEST) 발생시키고 필터 종료
+        if (accessTokenWithBearer == null || !accessTokenWithBearer.startsWith("Bearer ")) {
+            log.error("[JWTFilter] 액세스 토큰이 없습니다.");
+            throw new CustomException(ResponseCodeEnum.ACCESS_TOKEN_NULL);
+        }
+
+        // 2-1. 토큰에서 Bearer 제거하고 실질적인 토큰값을 가져오기
+        String accessToken = accessTokenWithBearer.split(" ")[1];
+
+       return accessToken;
+    }
+
+    public String getRequestSocialLoginUuid(HttpServletRequest request) {
+        String accessToken = getRequestAccessToken(request);
+        return jwtUtil.getSocialLoginUuid(accessToken);
+    }
+
+
+
+}


### PR DESCRIPTION
## #️⃣연관된 이슈
> #47 

## 📝작업 내용
- 일반 api 호출시 request에 담긴 accesstoken으로부터 SocialLoginUuid를 추출할 수 있는 메서드 구현하였습니다.
- AccessTokenService의 getRequestSocialLoginUuid 메서드를 활용하면 request로부터 토큰에 담긴 SocialLoginUuid를 추출할 수 있습니다.
![image](https://github.com/user-attachments/assets/e20263cc-4c4b-4f92-a28a-a26c1000d73e)

## 💬리뷰 요구사항(선택)
- 확인하시고 approve 부탁드립니다.

## ✅ 체크리스트
- [x] PR 제목 규칙 잘 지켰는가?
- [x] 추가/수정사항을 설명하였는가?
- [x] 이슈넘버를 적었는가?
