### PR TITLE
feat: STAFF 마이페이지 정보 조회 기능 구현

### DIFF
--- a/src/main/java/com/pawever/server/common/response/ResponseCodeEnum.java
+++ b/src/main/java/com/pawever/server/common/response/ResponseCodeEnum.java
@@ -30,6 +30,8 @@ public enum ResponseCodeEnum {
 
     // 사용자 관련 에러
     USER_NOT_FOUND(HttpStatus.NOT_FOUND, "USER_0", "user 정보를 찾을 수 없음."),
+    STAFF_NOT_FOUND(HttpStatus.NOT_FOUND, "USER_1", "staff 정보를 찾을 수 없음"),
+
 
     // S3 이미지 관련 에러
     UPLOAD_FAILED(HttpStatus.INTERNAL_SERVER_ERROR, "Image500_0", "이미지 업로드 중 오류가 발생했습니다."),

--- a/src/main/java/com/pawever/server/domain/carehub/entity/Shelter.java
+++ b/src/main/java/com/pawever/server/domain/carehub/entity/Shelter.java
@@ -78,4 +78,8 @@ public class Shelter {
         this.roadAddress = roadAddress;
     }
 
+    public void clearUserReference() {
+        this.user = null;
+    }
+
 }

--- a/src/main/java/com/pawever/server/domain/user/controller/UserController.java
+++ b/src/main/java/com/pawever/server/domain/user/controller/UserController.java
@@ -112,4 +112,10 @@ public class UserController {
 
     }
 
+    @GetMapping("/staffs")
+    public ResponseEntity<ApiResponse> getStaffProfiles(HttpServletRequest request){
+        return ResponseEntity
+            .ok(ApiResponse.success(ResponseCodeEnum.SUCCESS, userService.getStaffProfiles(request)));
+    }
+
 }

--- a/src/main/java/com/pawever/server/domain/user/dto/response/StaffProfileResponseDto.java
+++ b/src/main/java/com/pawever/server/domain/user/dto/response/StaffProfileResponseDto.java
@@ -1,0 +1,17 @@
+package com.pawever.server.domain.user.dto.response;
+
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Getter;
+
+@Getter
+@AllArgsConstructor
+@Builder
+public class StaffProfileResponseDto {
+    private String userName;
+    private String userEmail;
+    private String userProfileImageUrl;
+    private String shelterName;
+    private String shelterCenterPhoneNumber;
+    private String shelterManagerPhoneNumber;
+}

--- a/src/main/java/com/pawever/server/domain/user/entity/jpa/User.java
+++ b/src/main/java/com/pawever/server/domain/user/entity/jpa/User.java
@@ -1,6 +1,7 @@
 package com.pawever.server.domain.user.entity.jpa;
 
 import com.pawever.server.common.entity.BaseEntity;
+import com.pawever.server.domain.carehub.entity.Shelter;
 import com.pawever.server.domain.user.converter.BooleanToYNConverter;
 import com.pawever.server.domain.user.enums.Role;
 import jakarta.persistence.Column;
@@ -11,15 +12,18 @@ import jakarta.persistence.Enumerated;
 import jakarta.persistence.GeneratedValue;
 import jakarta.persistence.GenerationType;
 import jakarta.persistence.Id;
+import jakarta.persistence.OneToMany;
 import jakarta.persistence.Table;
 import java.math.BigDecimal;
 import java.time.LocalDateTime;
+import java.util.List;
 import lombok.AccessLevel;
 import lombok.AllArgsConstructor;
 import lombok.Builder;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
 import lombok.Setter;
+import lombok.extern.slf4j.Slf4j;
 
 @Entity
 @Getter
@@ -27,6 +31,7 @@ import lombok.Setter;
 @AllArgsConstructor(access = AccessLevel.PRIVATE)
 @Builder
 @Table(name = "user")
+@Slf4j
 public class User extends BaseEntity {
 
     @Id
@@ -71,6 +76,10 @@ public class User extends BaseEntity {
     @Convert(converter = BooleanToYNConverter.class)
     private Boolean isDeleted; // 삭제 여부, 기본값 false(N)
 
+    @Getter
+    @OneToMany(mappedBy = "user")
+    private List<Shelter> shelters; // 유저가 소유한 보호소 목록
+
     public void updateUserProfile(String name, String introduction){
         if(name != null){
             this.name = name;
@@ -86,5 +95,4 @@ public class User extends BaseEntity {
             this.profileImageUrl = profileImageUrl;
         }
     }
-
 }

--- a/src/main/java/com/pawever/server/domain/user/jwt/JwtFilter.java
+++ b/src/main/java/com/pawever/server/domain/user/jwt/JwtFilter.java
@@ -48,7 +48,7 @@ public class JwtFilter extends OncePerRequestFilter {
             (method.equalsIgnoreCase("POST"));
         boolean isLogoutRequest = path.equals("/api/auth/tokens") &&
             (method.equalsIgnoreCase("DELETE"));
-        boolean isWithdrawRequest = path.equals("/api/auth/tokens") &&
+        boolean isWithdrawRequest = path.equals("/api/users/profiles") &&
             (method.equalsIgnoreCase("DELETE"));
         boolean isGetAllPostRequest = path.equals("/api/community/posts") &&
                 (method.equalsIgnoreCase("GET"));

--- a/src/main/java/com/pawever/server/domain/user/repository/jpa/UserRepository.java
+++ b/src/main/java/com/pawever/server/domain/user/repository/jpa/UserRepository.java
@@ -1,6 +1,9 @@
 package com.pawever.server.domain.user.repository.jpa;
 
+import com.pawever.server.domain.carehub.entity.Shelter;
+import com.pawever.server.domain.user.dto.response.StaffProfileResponseDto;
 import com.pawever.server.domain.user.entity.jpa.User;
+import java.util.List;
 import java.util.Optional;
 import org.springframework.data.jpa.repository.JpaRepository;
 import org.springframework.data.jpa.repository.Modifying;
@@ -24,4 +27,13 @@ public interface UserRepository extends JpaRepository<User, Long> {
     @Transactional
     @Query("DELETE FROM User u WHERE u.socialLoginUuid = :socialLoginUuid")
     void hardDeleteByUuid(@Param("socialLoginUuid") String socialLoginUuid);
+
+    @Query(value = "SELECT u.name, u.email, u.profile_image_url, " +
+        "s.name, s.center_phone_number, s.manager_phone_number " +
+        "FROM user u JOIN shelter s ON u.user_id = s.user_id " +
+        "WHERE u.user_id = :userId",
+        nativeQuery = true)
+    List<StaffProfileResponseDto> findStaffProfileByUserId(@Param("userId") Long userId);
+
+    List<Shelter> findSheltersByUserId(Long userId);
 }

--- a/src/main/java/com/pawever/server/domain/user/service/UserService.java
+++ b/src/main/java/com/pawever/server/domain/user/service/UserService.java
@@ -2,9 +2,11 @@ package com.pawever.server.domain.user.service;
 
 import com.pawever.server.common.exception.CustomException;
 import com.pawever.server.common.response.ResponseCodeEnum;
+import com.pawever.server.domain.carehub.entity.Shelter;
 import com.pawever.server.domain.post.service.ImageService;
 import com.pawever.server.domain.user.dto.request.AuthRequestDto;
 import com.pawever.server.domain.user.dto.request.UserProfileUpdateRequestDto;
+import com.pawever.server.domain.user.dto.response.StaffProfileResponseDto;
 import com.pawever.server.domain.user.dto.response.UserProfileResponseDto;
 import com.pawever.server.domain.user.dto.response.UserResponseDto;
 import com.pawever.server.domain.user.entity.jpa.User;
@@ -14,6 +16,7 @@ import com.pawever.server.domain.user.repository.jpa.UserRepository;
 import jakarta.servlet.http.Cookie;
 import jakarta.servlet.http.HttpServletRequest;
 import jakarta.servlet.http.HttpServletResponse;
+import java.util.List;
 import java.util.Optional;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
@@ -97,6 +100,18 @@ public class UserService {
 
         // 5. Soft Delete 실행
         userRepository.softDeleteByUuid(userUuid);
+
+        // 6. staff인 경우, shelter 테이블에서 본인 user_id가 조회되는 경우 전부 null로 변경
+        if(user.getRole() == Role.ROLE_STAFF){
+            List<Shelter> staffShelterList = user.getShelters();
+            if(!staffShelterList.isEmpty()){
+                for(Shelter shelter : staffShelterList){
+                    log.info("[회원탈퇴] shelter 테이블내 담당자 user_id 제거 시작");
+                    shelter.clearUserReference();
+                    log.info("[회원탈퇴] shelter 테이블내 담당자 user_id 제거 완료");
+                }
+            }
+        }
     }
 
     @Transactional
@@ -192,4 +207,16 @@ public class UserService {
         }
     }
 
+    public List<StaffProfileResponseDto> getStaffProfiles(HttpServletRequest request) {
+        String staffAccessToken = accessTokenService.getRequestAccessToken(request);
+        Long staffUserId = jwtUtil.getUserId(staffAccessToken);
+
+        List<StaffProfileResponseDto> staffProfiles = userRepository.findStaffProfileByUserId(staffUserId);
+
+        if(staffProfiles.isEmpty()){
+            throw new CustomException(ResponseCodeEnum.STAFF_NOT_FOUND);        // 404 NOTFOUND 반환
+        }
+
+        return staffProfiles;
+    }
 }


### PR DESCRIPTION
## #️⃣연관된 이슈
> #77 

## 📝작업 내용
- STAFF(보호소 담담자) 마이페이지 정보 조회하는 기능 구현
- 유저명, 유저메일, 유저프로필이미지, 담당 보호소명, 보호소 연락처, 보호소 담당자 연락처를 가져오는 api입니다.
- STAFF의 회원탈퇴시(Soft Delete) Shelter 테이블내 Staff정보(user_id)를 제거하는 기능 추가하였습니다.

## 💬리뷰 요구사항(선택)
- 확인하시고 approve 부탁드립니다.

## ✅ 체크리스트
- [x] PR 제목 규칙 잘 지켰는가?
- [x] 추가/수정사항을 설명하였는가?
- [x] 이슈넘버를 적었는가?
