### PR TITLE
feat : 회원 및 관리자 파트 API 성공 응답 통일 

### DIFF
--- a/src/main/java/com/pawever/server/common/response/ResponseCodeEnum.java
+++ b/src/main/java/com/pawever/server/common/response/ResponseCodeEnum.java
@@ -70,6 +70,9 @@ public enum ResponseCodeEnum {
     INVALID_RESERVATION_TIME(HttpStatus.BAD_REQUEST,"RES_0","방문 예약이 불가능한 시간으로 예약을 요청함."),
     SHELTER_NOT_REGISTERED(HttpStatus.BAD_REQUEST,"RES_1","방문 예약이 불가능한 보호소를 대상으로 예약을 요청함."),
 
+    //응답 생성 관련
+    API_RESPONSE_WRITE_FAILED(HttpStatus.INTERNAL_SERVER_ERROR, "RESPONSE_0", "응답생성 중 에러가 발생했습니다."),
+
     //서버 에러
     UNKNOWN_SERVER_ERROR(HttpStatus.INTERNAL_SERVER_ERROR,"SERVER_0","처리하지 못한 서버 내부 error 발생");
 

--- a/src/main/java/com/pawever/server/domain/user/controller/AuthController.java
+++ b/src/main/java/com/pawever/server/domain/user/controller/AuthController.java
@@ -5,8 +5,8 @@ import com.pawever.server.common.response.ResponseCodeEnum;
 import com.pawever.server.domain.user.dto.request.AuthRequestDto;
 import com.pawever.server.domain.user.service.AuthService;
 import jakarta.servlet.http.HttpServletRequest;
-import jakarta.servlet.http.HttpServletResponse;
 import lombok.RequiredArgsConstructor;
+import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.PostMapping;
 import org.springframework.web.bind.annotation.RequestBody;
@@ -21,17 +21,19 @@ public class AuthController {
     private final AuthService authService;
 
     @PostMapping("/tokens")
-    public ResponseEntity<?> login(@RequestBody AuthRequestDto authRequestDto) {
-        return ResponseEntity.status(ResponseCodeEnum.NO_CONTENT.getStatus())
+    public ResponseEntity<ApiResponse> login(@RequestBody AuthRequestDto authRequestDto) {
+        return ResponseEntity
+            .status(HttpStatus.OK)
             .headers(authService.login(authRequestDto))
-            .build();
+            .body(ApiResponse.success(ResponseCodeEnum.SUCCESS));
     }
 
     @PostMapping("/refreshedtokens")
     public ResponseEntity<?> refreshTokens(HttpServletRequest request) {
-        return ResponseEntity.status(ResponseCodeEnum.NO_CONTENT.getStatus())
+        return ResponseEntity
+            .status(HttpStatus.OK)
             .headers(authService.refreshTokens(request))
-            .build();
+            .body(ApiResponse.success(ResponseCodeEnum.SUCCESS));
     }
 
 }

--- a/src/main/java/com/pawever/server/domain/user/controller/UserController.java
+++ b/src/main/java/com/pawever/server/domain/user/controller/UserController.java
@@ -5,11 +5,7 @@ import com.pawever.server.common.exception.CustomException;
 import com.pawever.server.common.response.ResponseCodeEnum;
 import com.pawever.server.domain.post.service.ImageService;
 import com.pawever.server.domain.user.dto.request.UserProfileUpdateRequestDto;
-import com.pawever.server.domain.user.dto.response.UserProfileResponseDto;
 import com.pawever.server.common.response.ApiResponse;
-import com.pawever.server.common.response.ResponseCodeEnum;
-import com.pawever.server.domain.reservation.service.ReservationService;
-import com.pawever.server.domain.user.dto.response.CustomUserDetails;
 import com.pawever.server.domain.user.enums.Role;
 import com.pawever.server.domain.user.jwt.JwtUtil;
 import com.pawever.server.domain.user.service.UserService;
@@ -19,7 +15,6 @@ import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.http.MediaType;
 import org.springframework.http.ResponseEntity;
-import org.springframework.security.core.annotation.AuthenticationPrincipal;
 import org.springframework.web.bind.annotation.*;
 import org.springframework.web.multipart.MultipartFile;
 
@@ -61,14 +56,14 @@ public class UserController {
         // 2. 회원정보 삭제
         userService.softDeleteUserByUuid(request);
 
-        return ResponseEntity.noContent().build(); // 204 No Content 반환
+        return ResponseEntity.ok(ApiResponse.success(ResponseCodeEnum.SUCCESS)); // 200 SUCCESS 반환
     }
 
 
     @GetMapping("/profiles")
-    public ResponseEntity<UserProfileResponseDto> getUserProfiles(HttpServletRequest request){
+    public ResponseEntity<ApiResponse> getUserProfiles(HttpServletRequest request){
         return ResponseEntity
-            .ok(userService.getUserProfiles(request));  // 200(ok) + UserResponseDto 반환
+            .ok(ApiResponse.success(ResponseCodeEnum.SUCCESS, userService.getUserProfiles(request)));
     }
 
     @GetMapping("/upload/defaultimages")
@@ -83,14 +78,15 @@ public class UserController {
     }
 
     @PatchMapping(value="/profiles", consumes = MediaType.MULTIPART_FORM_DATA_VALUE)
-    public ResponseEntity<String> updateUserProfile(
+    public ResponseEntity<ApiResponse> updateUserProfile(
         @RequestPart(value = "data", required = false) UserProfileUpdateRequestDto userProfileUpdateRequestDto,
         @RequestPart(value = "profileImage", required = false) MultipartFile profileImageFile,
         HttpServletRequest request
     ) {
         userService.updateUserProfile(userProfileUpdateRequestDto, profileImageFile, request);
 
-        return ResponseEntity.noContent().build(); // 성공시 204 코드 반환(Response body 없음)
+        return ResponseEntity
+            .ok(ApiResponse.success(ResponseCodeEnum.SUCCESS));
     }
 
     @GetMapping("/staffs")

--- a/src/main/java/com/pawever/server/domain/user/jwt/CustomLogoutFilter.java
+++ b/src/main/java/com/pawever/server/domain/user/jwt/CustomLogoutFilter.java
@@ -36,5 +36,6 @@ public class CustomLogoutFilter extends GenericFilterBean {
 
         // 2. 로그아웃 진행
         userService.logout(request, response);
+        userService.createLogoutResponse(response);
     }
 }

--- a/src/main/java/com/pawever/server/domain/user/service/UserService.java
+++ b/src/main/java/com/pawever/server/domain/user/service/UserService.java
@@ -1,6 +1,8 @@
 package com.pawever.server.domain.user.service;
 
+import com.fasterxml.jackson.databind.ObjectMapper;
 import com.pawever.server.common.exception.CustomException;
+import com.pawever.server.common.response.ApiResponse;
 import com.pawever.server.common.response.ResponseCodeEnum;
 import com.pawever.server.domain.carehub.service.ShelterService;
 import com.pawever.server.domain.carehub.entity.Shelter;
@@ -17,6 +19,7 @@ import com.pawever.server.domain.user.repository.jpa.UserRepository;
 import jakarta.servlet.http.Cookie;
 import jakarta.servlet.http.HttpServletRequest;
 import jakarta.servlet.http.HttpServletResponse;
+import java.io.IOException;
 import java.util.List;
 import java.util.Optional;
 import lombok.RequiredArgsConstructor;
@@ -37,6 +40,7 @@ public class UserService {
     private final JwtUtil jwtUtil;
     private final ImageService imageService;
     private final UserImageService userImageService;
+    private final ObjectMapper objectMapper;
 
     public UserResponseDto getUserInfoByUuid(String socialLoginUuid){
 
@@ -138,8 +142,16 @@ public class UserService {
         cookie.setSecure(false);   // (HTTP 환경에서는 `Secure` 설정을 false로 해주세요)
 
         response.addCookie(cookie);
-        response.setStatus(HttpServletResponse.SC_NO_CONTENT);  // 204 응답코드 전송
+    }
 
+    public void createLogoutResponse(HttpServletResponse response){
+        try {
+            response.getWriter().write(objectMapper.writeValueAsString(ApiResponse.success(ResponseCodeEnum.SUCCESS)));
+        } catch (IOException e) {
+            // 응답생성실패시 500 INTERNAL SERVER ERROR 반환
+            throw new CustomException(ResponseCodeEnum.API_RESPONSE_WRITE_FAILED);
+        }
+        response.setStatus(HttpServletResponse.SC_OK);  // 200 응답코드 전송
     }
 
     public UserProfileResponseDto getUserProfiles(HttpServletRequest request) {


### PR DESCRIPTION
## #️⃣연관된 이슈
> #93 

## 📝작업 내용
- 회원(로그인, 로그아웃, 회원탈퇴, 회원조회 등) 및 관리자 파트(관리자 조회) API 성공 응답을 ApiResponse 클래스를 사용하는 방식으로 통일했습니다.
- CustomLogoutFilter(로그아웃 기능)과 AuthController의 withdraw(회원탈퇴 기능)이 userService의 logout 메서드를 공유하고 있는데, CustomLogoutFilter는 HttpServletResponse 객체를 통해서 응답을 생성해서 반환하는 반면 withdraw는 컨트롤러단에서 ResponseEntity를 통해 응답을 생성하다보니 logout 메서드 안에서 HttpServeltResponse를 통해서 responseBody를 생성해버릴 경우 withdraw 컨트롤러의 응답생성 부분과 충돌하는 문제가 발생합니다. 이에 CustomLogoutFilter와 withdraw에서 공통으로 사용하는 부분(쿠키초기화)만 logout 메서드에 두고, 로그아웃 성공시 응답을 생성하는 코드는 createLogoutResponse라는 별도의 메서드로 분리하였습니다.
- 상기 내용은 노션 "~/백엔드회의록/최종 마무리된 API" 및 Slack 팀 채널에 공유하여 프론트 분들이 확인하실 수 있도록 하겠습니다.

## 💬리뷰 요구사항(선택)
- 확인하시고 승인 부탁드립니다.

## ✅ 체크리스트
- [x] PR 제목 규칙 잘 지켰는가?
- [x] 추가/수정사항을 설명하였는가?
- [x] 이슈넘버를 적었는가?
