### PR TITLE
feat : 프론트 개발환경에서 로그인시 쿠키를 전달 받을 수 있도록 crossSite 요청에 대해 쿠키 허용

### DIFF
--- a/src/main/java/com/pawever/server/domain/user/service/AuthService.java
+++ b/src/main/java/com/pawever/server/domain/user/service/AuthService.java
@@ -102,10 +102,13 @@ public class AuthService {
     }
 
     private String createCookieHeader(String name, String value) {
-        return name + "=" + value + "; Path=/; HttpOnly; Max-Age=" + (refreshTokenExpiredMs);
+        // 프론트 로컬에서 임시로 접근 가능하도록 설정
+        return name + "=" + value + "; Path=/; HttpOnly; SameSite=None;  Max-Age=" + (refreshTokenExpiredMs);
 
-        // https 설정
-//        return name + "=" + value + "; Path=/; HttpOnly; Secure;  Max-Age=" + (refreshTokenExpiredMs);
+        // 프론트 배포시 적용할 설정(https에서만 쿠키 전달 + 크로스 사이트 요청에 대해 쿠키 전송 허용)
+        //return name + "=" + value + "; Path=/; HttpOnly; Secure; SameSite=None; Max-Age=" + (refreshTokenExpiredMs);
+
+
     }
 
 


### PR DESCRIPTION
## #️⃣연관된 이슈
> #112 

## 📝작업 내용
- 로그인 성공시 refreshtoken을 쿠키에 포함시켜 응답하는데, 프론트 개발환경에서 크로스 사이트 요청을 보내는 경우 쿠키를 받지 못하는 문제가 발생헀습니다.
- 쿠키 생성시 SameSite=None 으로 명시적으로 표기하여 모든 크로스 사이트 요청에 대해서 쿠키를 허용하도록 임시로 변경하였습니다.
- 다만, SameSite=None 속성은 반드시 secure(https에 대해서만 허용) 속성과 같이 사용해야 한다는 문제가 예상되어, 우선 프론트 담당자와 테스트 해보고 에러 발생시 다른 방법으로 문제 해결할 예정입니다.

## 💬리뷰 요구사항(선택)
- 확인하시고 승인 부탁드립니다.

## ✅ 체크리스트
- [x] PR 제목 규칙 잘 지켰는가?
- [x] 추가/수정사항을 설명하였는가?
- [x] 이슈넘버를 적었는가?
