### PR TITLE
feat : 회원탈퇴 API 성공 응답 방식 수정, 테스트용 API 제거 및 Swagger 문서 회원관리 파트 수정

### DIFF
--- a/src/main/java/com/pawever/server/common/config/SecurityConfig.java
+++ b/src/main/java/com/pawever/server/common/config/SecurityConfig.java
@@ -71,7 +71,7 @@ public class SecurityConfig {
                 .requestMatchers(HttpMethod.GET, "/api/community/posts/**").permitAll()  // 게시글 단건 조회
                 .requestMatchers(HttpMethod.GET, "/api/animals").permitAll()  // 유기동물 조회(메인)
                 .requestMatchers(HttpMethod.GET,"/api/animals/search/**").permitAll()  // 유기동물 조회(입양 동물 정보)
-                .requestMatchers("/admin/**").hasRole("ADMIN") // 권한 설정
+                .requestMatchers("/admin/**, /api/users/upload/defaultimages").hasRole("ADMIN") // 권한 설정
                 .requestMatchers("/api/users/staff/**","/api/reservations/staff").hasRole("STAFF") // 권한 설정
                 .anyRequest().authenticated()
             );

--- a/src/main/java/com/pawever/server/domain/user/controller/AuthController.java
+++ b/src/main/java/com/pawever/server/domain/user/controller/AuthController.java
@@ -19,12 +19,13 @@ import org.springframework.web.bind.annotation.RestController;
 @RestController
 @RequiredArgsConstructor
 @RequestMapping("/api/auth")
+@Tag(name = "인증 API", description = "JWT 토큰 발급(로그인) 및 재발급 API")
 public class AuthController {
 
     private final AuthService authService;
 
     @PostMapping("/tokens")
-    @Operation(summary = "로그인 및 액세스 토큰 발급")
+    @Operation(summary = "로그인 및 JWT 토큰(액세스/리프레시) 발급 API")
     public ResponseEntity<ApiResponse> login(@RequestBody AuthRequestDto authRequestDto) {
         return ResponseEntity
             .status(HttpStatus.OK)
@@ -33,7 +34,7 @@ public class AuthController {
     }
 
     @PostMapping("/refreshedtokens")
-    @Operation(summary = "리프레시 토큰으로 액세스 토큰 발급")
+    @Operation(summary = "JWT 토큰(액세스/리프레시) 재발급 API")
     public ResponseEntity<?> refreshTokens(HttpServletRequest request) {
         return ResponseEntity
             .status(HttpStatus.OK)

--- a/src/main/java/com/pawever/server/domain/user/controller/UserController.java
+++ b/src/main/java/com/pawever/server/domain/user/controller/UserController.java
@@ -59,7 +59,7 @@ public class UserController {
     }
 
     @GetMapping("/upload/defaultimages")
-    @Operation(summary = "기본 프로필 이미지 조회 API")
+    @Operation(summary = "기본 프로필 이미지 S3 업로드 API", hidden = true)
     public ResponseEntity<String> uploadDefaultUserImage(@RequestParam("file") MultipartFile file){
         // user 디폴트 이미지를 s3에 올리고 링크를 반환받는 api
         // 반환되는 객체 uri를 회원가입시 이미지가 없는 유저 profile image url에 매핑
@@ -84,13 +84,14 @@ public class UserController {
     }
 
     @GetMapping("/staffs")
-    @Operation(summary = "스태프 목록 조회")
+    @Operation(summary = "스태프 목록 조회 API")
     public ResponseEntity<ApiResponse> getStaffProfiles(HttpServletRequest request){
         return ResponseEntity
             .ok(ApiResponse.success(ResponseCodeEnum.SUCCESS, userService.getStaffProfiles(request)));
     }
 
     @GetMapping("/roles")
+    @Operation(summary = "특정 사용자 권한 조회 API")
     public ResponseEntity<ApiResponse> getUserRoles(HttpServletRequest request){
         String accessToken = accessTokenService.getRequestAccessToken(request);
         Role userRole = jwtUtil.getRole(accessToken);
@@ -99,6 +100,7 @@ public class UserController {
     }
 
     @PatchMapping("/roles")
+    @Operation(summary = "특정 사용자 권한 변경 API")
     public ResponseEntity<ApiResponse> updateUserRoles(@RequestParam("role") String inputRole, HttpServletRequest request){
 
         userService.updateUserRoles(inputRole, request);

--- a/src/main/java/com/pawever/server/domain/user/controller/UserController.java
+++ b/src/main/java/com/pawever/server/domain/user/controller/UserController.java
@@ -48,7 +48,7 @@ public class UserController {
         // 2. 회원정보 삭제
         userService.softDeleteUserByUuid(request);
 
-        return ResponseEntity.noContent().build(); // 204 No Content 반환
+        return ResponseEntity.ok(ApiResponse.success(ResponseCodeEnum.SUCCESS)); // 200 SUCCESS 반환
     }
 
     @GetMapping("/profiles")

--- a/src/main/java/com/pawever/server/domain/user/controller/UserController.java
+++ b/src/main/java/com/pawever/server/domain/user/controller/UserController.java
@@ -38,26 +38,6 @@ public class UserController {
     private final ImageService imageService;
     private final AccessTokenService accessTokenService;
 
-    @GetMapping("/admin")
-    @Operation(summary = "admin 권한 확인용 테스트 API")
-    public String admin(HttpServletRequest request) {
-        // admin 권한 확인용 테스트 컨트롤러입니다.
-
-        String accessTokenWithBearer= request.getHeader("Authorization");
-        log.info("accessTokenWithBearer: " + accessTokenWithBearer);
-
-        String accessToken = accessTokenWithBearer.split(" ")[1];
-        String category = jwtUtil.getCategory(accessToken);
-        String socialLoginUuid = jwtUtil.getSocialLoginUuid(accessToken);
-        Role role = jwtUtil.getRole(accessToken);
-
-        log.info("category: "+category);
-        log.info("socialLoginUuid: "+socialLoginUuid);
-        log.info("role: "+role.name());
-
-        return "admin authority confirmed";
-    }
-
     @DeleteMapping("/profiles")
     @Operation(summary = "회원 탈퇴 API")
     public ResponseEntity<?> withdraw(HttpServletRequest request, HttpServletResponse response){


### PR DESCRIPTION
## #️⃣연관된 이슈
> #110, #93

## 📝작업 내용
- #93 에서 회원관리 API 성공 응답방식을 모두 통일했으나, merge 과정에서 변경된 회원탈퇴 API 성공 응답 방식이 누락되어 누락된 코드 반영
- UserController에서 테스트용으로 추가했던 "GET /admin" 제거
- 회원관리 Swagger 문서 내용 실제 API 내용에 맞춰 AuthController의 제목을 설정해주었으며, AuthController 및 UserController 상의 메서드들의 description을 수정해주었습니다.
- 유저 디폴트 이미지를 Aws S3에 업로드하는 API(GET /api/users/upload/defaultimages)는 백엔드 내부적으로만 사용하는 API로 ADMIN 권한으로 설정했으며, Swagger에서 제외했습니다.

## 💬리뷰 요구사항(선택)
- 확인하시고 승인 부탁드립니다.

## ✅ 체크리스트
- [x] PR 제목 규칙 잘 지켰는가?
- [x] 추가/수정사항을 설명하였는가?
- [x] 이슈넘버를 적었는가?
