### PR TITLE
fix : SameSite=None 설정시 Secure 설정이 필수인 관계로 추가

### DIFF
--- a/src/main/java/com/pawever/server/domain/user/service/AuthService.java
+++ b/src/main/java/com/pawever/server/domain/user/service/AuthService.java
@@ -103,7 +103,7 @@ public class AuthService {
 
     private String createCookieHeader(String name, String value) {
         // 프론트 로컬에서 임시로 접근 가능하도록 설정
-        return name + "=" + value + "; Path=/; HttpOnly; SameSite=None;  Max-Age=" + (refreshTokenExpiredMs);
+        return name + "=" + value + "; Path=/; HttpOnly; Secure; SameSite=None;  Max-Age=" + (refreshTokenExpiredMs);
 
         // 프론트 배포시 적용할 설정(https에서만 쿠키 전달 + 크로스 사이트 요청에 대해 쿠키 전송 허용)
         //return name + "=" + value + "; Path=/; HttpOnly; Secure; SameSite=None; Max-Age=" + (refreshTokenExpiredMs);


### PR DESCRIPTION
## #️⃣연관된 이슈
> #112 

## 📝작업 내용
- SameSite=None으로 설정할 경우 Secure 설정을 추가하여 https 요청에 대해서만 쿠키를 추가해서 보내도록 변경하였습니다.

## 💬리뷰 요구사항(선택)
- 확인후 승인 부탁드립니다.

## ✅ 체크리스트
- [x] PR 제목 규칙 잘 지켰는가?
- [x] 추가/수정사항을 설명하였는가?
- [x] 이슈넘버를 적었는가?
