### PR TITLE
feat : 프론트에서 로그아웃하고 재로그인시 소셜로그인 정보로 프로필이 덮어씌워지는 원인 분석을 위한 로그 추가

### DIFF
--- a/src/main/java/com/pawever/server/domain/user/service/AuthService.java
+++ b/src/main/java/com/pawever/server/domain/user/service/AuthService.java
@@ -35,8 +35,18 @@ public class AuthService {
     @Transactional
     public HttpHeaders login(AuthRequestDto authRequestDto) {
 
-        // 1. authRequestDto의 uuid를 기준으로 User 테이블에서 사용자 조회
-        UserResponseDto userResponseDto = userService.getUserInfoByUuid(authRequestDto.getSocialLoginUuid());
+        UserResponseDto userResponseDto = null;
+
+        if(authRequestDto == null){
+            log.error("회원가입실패 : AuthRequestDto null");
+            throw new CustomException(ResponseCodeEnum.MISSING_REQUIRED_FIELDS);
+        }
+
+        if(authRequestDto.getSocialLoginUuid() != null) {
+            log.info("로그인 시도 - 소셜로그인uuid: {}", authRequestDto.getSocialLoginUuid());
+            // 1. authRequestDto의 uuid를 기준으로 User 테이블에서 사용자 조회
+            userResponseDto = userService.getUserInfoByUuid(authRequestDto.getSocialLoginUuid());
+        }
 
         // 2. userResponseDto 값이 null이면 회원가입 진행
         if(userResponseDto == null){


### PR DESCRIPTION
## #️⃣연관된 이슈
> #132 

## 📝작업 내용
- 프론트에서 로그아웃하고 재로그인시 소셜로그인 정보로 프로필이 덮어씌워지는 원인 분석을 위한 로그 추가

## 💬리뷰 요구사항(선택)
- 확인하시고 승인 부탁드립니다.

## ✅ 체크리스트
- [x] PR 제목 규칙 잘 지켰는가?
- [x] 추가/수정사항을 설명하였는가?
- [x] 이슈넘버를 적었는가?
