### PR TITLE
feat : 유저프로필조회시 introduction을 가져오지 못하는 문제 해결

### DIFF
--- a/src/main/java/com/pawever/server/domain/user/dto/response/UserProfileResponseDto.java
+++ b/src/main/java/com/pawever/server/domain/user/dto/response/UserProfileResponseDto.java
@@ -1,5 +1,6 @@
 package com.pawever.server.domain.user.dto.response;
 
+import com.fasterxml.jackson.annotation.JsonInclude;
 import lombok.AllArgsConstructor;
 import lombok.Builder;
 import lombok.Getter;
@@ -7,8 +8,10 @@ import lombok.Getter;
 @Getter
 @AllArgsConstructor
 @Builder
+@JsonInclude(JsonInclude.Include.NON_NULL)
 public class UserProfileResponseDto {
     private String name;
     private String email;
     private String profileImageUrl;
+    private String introduction;
 }

--- a/src/main/java/com/pawever/server/domain/user/service/UserService.java
+++ b/src/main/java/com/pawever/server/domain/user/service/UserService.java
@@ -164,6 +164,7 @@ public class UserService {
                 .name(user.getName())
                 .email(user.getEmail())
                 .profileImageUrl(user.getProfileImageUrl())
+                .introduction(user.getIntroduction())
                 .build())
             .orElseThrow(() -> new CustomException(ResponseCodeEnum.USER_NOT_FOUND));
     }


### PR DESCRIPTION
## #️⃣연관된 이슈
> #138 

## 📝작업 내용
- 유저 프로필 조회시 introduction을 가져오지 못하는 문제를 해결하기 위해서 introduction을 가져오는 코드 추가헀습니다.
- 첫 회원가입후 자기소개를 입력하지 않을 경우 introduction이 null이기 때문에, UserProfileResponsedata 클래스에 introduction이null인 경우 응답에서 제거하도록 처리하였습니다.

## 💬리뷰 요구사항(선택)
- 확인하시고 승인 부탁드립니다.

## ✅ 체크리스트
- [x] PR 제목 규칙 잘 지켰는가?
- [x] 추가/수정사항을 설명하였는가?
- [x] 이슈넘버를 적었는가?
