### PR TITLE
feat : 로그인시 유저정보를 보내는 클라이언트 검증 로직 추가 

### DIFF
--- a/src/main/java/com/pawever/server/common/config/SecurityConfig.java
+++ b/src/main/java/com/pawever/server/common/config/SecurityConfig.java
@@ -57,6 +57,7 @@ public class SecurityConfig {
         http
             .authorizeHttpRequests((auth) -> auth
                 .requestMatchers(HttpMethod.POST, "/api/auth/tokens").permitAll()  // 로그인 요청시 허용
+                .requestMatchers(HttpMethod.GET, "/api/auth/tokens/attempts").permitAll()  // PreLogin 요청시 허용
                 .requestMatchers("/error").permitAll()
                 .requestMatchers("/v3/api-docs/**").permitAll()
                 .requestMatchers("/docs/**").permitAll()

--- a/src/main/java/com/pawever/server/common/response/ResponseCodeEnum.java
+++ b/src/main/java/com/pawever/server/common/response/ResponseCodeEnum.java
@@ -20,12 +20,15 @@ public enum ResponseCodeEnum {
     JWT_TOKEN_INVALID(HttpStatus.UNAUTHORIZED, "AUTH_1", "JWT 토큰이 유효하지 않습니다."),
     INSUFFICIENT_PERMISSIONS(HttpStatus.FORBIDDEN, "AUTH_2", "권한이 부족합니다."),
 
-
     COOKIE_NULL(HttpStatus.BAD_REQUEST, "AUTH_3", "Cookie가 존재하지 않습니다."),
     REFRESH_TOKEN_NULL(HttpStatus.BAD_REQUEST, "AUTH_4", "Refresh Token이 존재하지 않습니다."),
     TOKEN_CATEGORY_MISMATCH(HttpStatus.BAD_REQUEST, "AUTH_5", "Token 카테고리가 Refresh와 일치하지 않습니다."),
     REFRESH_TOKEN_NOT_FOUND(HttpStatus.UNAUTHORIZED, "AUTH_6", "서버에 존재하지 않는 Refresh Token입니다."),
     ACCESS_TOKEN_NULL(HttpStatus.BAD_REQUEST, "AUTH_7", "Access Token이 존재하지 않습니다."),
+
+    CODE_CHALLENGE_NULL(HttpStatus.BAD_REQUEST, "AUTH_8", "Code Challenge가 존재하지 않습니다."),
+    UNIDENTIFIED_CLIENT(HttpStatus.UNAUTHORIZED, "AUTH_9", "클라이언트 정보를 확인할 수 없습니다."),
+    UNSUPPORTED_HASH_ALGORITHM(HttpStatus.BAD_REQUEST, "AUTH_10", "지원되지 않는 Hash 알고리즘입니다."),
 
 
     // 사용자 관련 에러

--- a/src/main/java/com/pawever/server/domain/user/controller/AuthController.java
+++ b/src/main/java/com/pawever/server/domain/user/controller/AuthController.java
@@ -1,36 +1,64 @@
 package com.pawever.server.domain.user.controller;
 
+import com.pawever.server.common.exception.CustomException;
 import com.pawever.server.common.response.ApiResponse;
 import com.pawever.server.common.response.ResponseCodeEnum;
-import com.pawever.server.domain.user.dto.request.AuthRequestDto;
+import com.pawever.server.domain.user.dto.request.AuthLoginRequestDto;
+import com.pawever.server.domain.user.dto.request.AuthPreLoginRequestDto;
 import com.pawever.server.domain.user.service.AuthService;
 import io.swagger.v3.oas.annotations.Operation;
 import io.swagger.v3.oas.annotations.tags.Tag;
 import jakarta.servlet.http.HttpServletRequest;
-import jakarta.servlet.http.HttpServletResponse;
 import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.PostMapping;
 import org.springframework.web.bind.annotation.RequestBody;
 import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RequestParam;
 import org.springframework.web.bind.annotation.RestController;
 
 @RestController
 @RequiredArgsConstructor
 @RequestMapping("/api/auth")
 @Tag(name = "인증 API", description = "JWT 토큰 발급(로그인) 및 재발급 API")
+@Slf4j
 public class AuthController {
 
     private final AuthService authService;
 
     @PostMapping("/tokens")
     @Operation(summary = "로그인 및 JWT 토큰(액세스/리프레시) 발급 API")
-    public ResponseEntity<ApiResponse> login(@RequestBody AuthRequestDto authRequestDto) {
+    public ResponseEntity<ApiResponse> login(@RequestBody AuthLoginRequestDto authLoginRequestDto) {
         return ResponseEntity
             .status(HttpStatus.OK)
-            .headers(authService.login(authRequestDto))
+            .headers(authService.login(authLoginRequestDto))
             .body(ApiResponse.success(ResponseCodeEnum.SUCCESS));
+    }
+
+    @GetMapping("/tokens/attempts")
+    @Operation(summary = "로그인전 서버에 Code Challenge를 보내 Code Challenge를 담은 토큰을 반환받는 API")
+    public ResponseEntity<ApiResponse> preLogin(
+        @RequestParam(required = false) String codeChallenge,
+        @RequestParam(required = false) String codeChallengeMethod
+    ) {
+        // codeChallenge가 없다면 400 BadRequest 반환
+        if(codeChallenge==null||codeChallenge.isEmpty()){
+            throw new CustomException(ResponseCodeEnum.CODE_CHALLENGE_NULL);
+        }
+
+        // 1. DTO 생성해서 codeChallenge, codeChallengeMethod 담기
+        AuthPreLoginRequestDto authPreLoginRequestDto = AuthPreLoginRequestDto.builder()
+            .codeChallenge(codeChallenge)
+            .codeChallengeMethod(codeChallengeMethod).build();
+
+        log.info("code Challenge: ", authPreLoginRequestDto.getCodeChallenge());
+        log.info("code ChallengeMethod: ", authPreLoginRequestDto.getCodeChallengeMethod());
+        // 2. codeChallenge, codeChallengeMethod를 담은 Jwt를 응답
+        return ResponseEntity
+            .ok(ApiResponse.success(ResponseCodeEnum.SUCCESS, authService.preLogin(authPreLoginRequestDto)));
     }
 
     @PostMapping("/refreshedtokens")

--- a/src/main/java/com/pawever/server/domain/user/dto/request/AuthLoginRequestDto.java
+++ b/src/main/java/com/pawever/server/domain/user/dto/request/AuthLoginRequestDto.java
@@ -11,7 +11,7 @@ import lombok.NoArgsConstructor;
 @Builder
 @NoArgsConstructor
 @AllArgsConstructor
-public class AuthRequestDto {
+public class AuthLoginRequestDto {
     private String socialLoginUuid;         //소셜로그인 uuid
     private String name;                    //소셜로그인 닉네임
     //프로필 이미지
@@ -21,4 +21,6 @@ public class AuthRequestDto {
     private String socialLoginProvider;     //카카오 or 구글
     private BigDecimal latitude;            //사용자 위치 - 위도
     private BigDecimal longitude;           //사용자 위치 - 경도
+    private String codeVerifier;            // 클라이언트 검증용 codeVerifier
+    private String preLoginJwt;             // 클라이언트 검증용 jwt(pre-login단계에서 클라이언트에게 전달한 jwt)
 }

--- a/src/main/java/com/pawever/server/domain/user/dto/request/AuthPreLoginRequestDto.java
+++ b/src/main/java/com/pawever/server/domain/user/dto/request/AuthPreLoginRequestDto.java
@@ -1,0 +1,18 @@
+package com.pawever.server.domain.user.dto.request;
+
+
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@Getter
+@Builder
+@NoArgsConstructor
+@AllArgsConstructor
+public class AuthPreLoginRequestDto {
+    private String codeChallenge;
+    // codeChallengeMethod가 전달되지 않는 경우 plain을 default로 설정하도록 세팅
+    @Builder.Default
+    private String codeChallengeMethod="plain";
+}

--- a/src/main/java/com/pawever/server/domain/user/jwt/JwtFilter.java
+++ b/src/main/java/com/pawever/server/domain/user/jwt/JwtFilter.java
@@ -42,6 +42,8 @@ public class JwtFilter extends OncePerRequestFilter {
         String method = request.getMethod();
 
         // 🔹 기존 인증 제외 조건: POST, PUT /api/auth/tokens
+        boolean isPreLoginRequest = path.equals("/api/auth/tokens/attempts") &&
+            (method.equalsIgnoreCase("GET"));
         boolean isLoginRequest = path.equals("/api/auth/tokens") &&
             (method.equalsIgnoreCase("POST"));
         boolean isTokenRefreshRequest = path.equals("/api/auth/refreshedtokens") &&
@@ -72,7 +74,7 @@ public class JwtFilter extends OncePerRequestFilter {
         boolean swaggerRequest6 = path.startsWith("/docs");
         boolean allRequestAllowance = path.startsWith("/");  // 로그인 기능 완전히 구현할때까지 우선 모두 허용
 //        return allRequestAllowance;
-        return isLoginRequest || isTokenRefreshRequest ||isLogoutRequest || isWithdrawRequest || isGetAllPostRequest || isGetSearchPostRequest || isGetPostRequest || isGetPetMainRequest || isGetPetRequest || swaggerRequest1 || swaggerRequest2 || swaggerRequest3 || swaggerRequest4 || swaggerRequest5 || swaggerRequest6 ||isGetRepliesRequest;
+        return isPreLoginRequest || isLoginRequest || isTokenRefreshRequest ||isLogoutRequest || isWithdrawRequest || isGetAllPostRequest || isGetSearchPostRequest || isGetPostRequest || isGetPetMainRequest || isGetPetRequest || swaggerRequest1 || swaggerRequest2 || swaggerRequest3 || swaggerRequest4 || swaggerRequest5 || swaggerRequest6 ||isGetRepliesRequest;
     }
 
     // JWTUtil 클래스에 정의해두었던 Jwt토큰 검증에 사용되는 메서드들을 사용해야하므로

--- a/src/main/java/com/pawever/server/domain/user/jwt/JwtUtil.java
+++ b/src/main/java/com/pawever/server/domain/user/jwt/JwtUtil.java
@@ -1,6 +1,7 @@
 package com.pawever.server.domain.user.jwt;
 
 
+import com.pawever.server.domain.user.dto.request.AuthPreLoginRequestDto;
 import com.pawever.server.domain.user.dto.response.UserResponseDto;
 import com.pawever.server.domain.user.enums.Role;
 import io.jsonwebtoken.Jwts;
@@ -45,12 +46,27 @@ public class JwtUtil {
         return Jwts.parser().verifyWith(secretKey).build().parseSignedClaims(token).getPayload().getExpiration().before(new Date());
     }
 
+    public String getCodeChallenge(String token) {
+        return Jwts.parser().verifyWith(secretKey).build().parseSignedClaims(token).getPayload().get("codeChallenge", String.class);
+    }
+
+    public String getCodeChallengeMethod(String token) {
+        return Jwts.parser().verifyWith(secretKey).build().parseSignedClaims(token).getPayload().get("codeChallengeMethod", String.class);
+    }
+
     public UserResponseDto getUserResponseDto(String token){
         return UserResponseDto.builder()
             .userId(getUserId(token))
             .socialLoginUuid(getSocialLoginUuid(token))
             .name(getName(token))
             .role(getRole(token))
+            .build();
+    }
+
+    public AuthPreLoginRequestDto getAuthPreLoginRequestDto(String token){
+        return AuthPreLoginRequestDto.builder()
+            .codeChallenge(getCodeChallenge(token))
+            .codeChallengeMethod(getCodeChallengeMethod(token))
             .build();
     }
 
@@ -62,6 +78,18 @@ public class JwtUtil {
             .claim("socialLoginUuid", userResponseDto.getSocialLoginUuid())
             .claim("name", userResponseDto.getName())
             .claim("role", userResponseDto.getRole())
+            .issuedAt(new Date(System.currentTimeMillis()))
+            .expiration(new Date(System.currentTimeMillis() + expiredMs))
+            .signWith(secretKey)
+            .compact();
+    }
+
+    public String createJwt(String category, AuthPreLoginRequestDto authPreLoginRequestDto, Long expiredMs) {
+
+        return Jwts.builder()
+            .claim("category", category)        // refresh, access 토큰 구분
+            .claim("codeChallenge", authPreLoginRequestDto.getCodeChallenge())
+            .claim("codeChallengeMethod", authPreLoginRequestDto.getCodeChallengeMethod())
             .issuedAt(new Date(System.currentTimeMillis()))
             .expiration(new Date(System.currentTimeMillis() + expiredMs))
             .signWith(secretKey)

--- a/src/main/java/com/pawever/server/domain/user/service/AuthService.java
+++ b/src/main/java/com/pawever/server/domain/user/service/AuthService.java
@@ -2,14 +2,17 @@ package com.pawever.server.domain.user.service;
 
 import com.pawever.server.common.exception.CustomException;
 import com.pawever.server.common.response.ResponseCodeEnum;
-import com.pawever.server.domain.user.dto.request.AuthRequestDto;
+import com.pawever.server.domain.user.dto.request.AuthLoginRequestDto;
+import com.pawever.server.domain.user.dto.request.AuthPreLoginRequestDto;
 import com.pawever.server.domain.user.dto.response.UserResponseDto;
 import com.pawever.server.domain.user.jwt.JwtUtil;
 
-import io.jsonwebtoken.ExpiredJwtException;
-import jakarta.servlet.http.Cookie;
 import jakarta.servlet.http.HttpServletRequest;
-import jakarta.servlet.http.HttpServletResponse;
+import java.nio.charset.StandardCharsets;
+import java.security.MessageDigest;
+import java.security.NoSuchAlgorithmException;
+import java.util.Base64;
+import java.util.Base64.Encoder;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.beans.factory.annotation.Value;
@@ -33,49 +36,58 @@ public class AuthService {
     private Long refreshTokenExpiredMs;
 
     @Transactional
-    public HttpHeaders login(AuthRequestDto authRequestDto) {
+    public HttpHeaders login(AuthLoginRequestDto authLoginRequestDto) {
 
-        UserResponseDto userResponseDto = null;
-
-        if(authRequestDto == null){
-            log.error("회원가입실패 : AuthRequestDto null");
+        // refactor : null 처리 코드 줄이기
+        if(authLoginRequestDto == null){
+            log.error("회원가입/로그인실패 : AuthRequestDto null");
             throw new CustomException(ResponseCodeEnum.MISSING_REQUIRED_FIELDS);
         }
+        UserResponseDto userResponseDto = null;
 
-        if(authRequestDto.getSocialLoginUuid() != null) {
-            log.info("로그인 시도 - 소셜로그인uuid: {}", authRequestDto.getSocialLoginUuid());
-            // 1. authRequestDto의 uuid를 기준으로 User 테이블에서 사용자 조회
-            userResponseDto = userService.getUserInfoByUuid(authRequestDto.getSocialLoginUuid());
+        // 1. 클라이언트 검증
+        verifyClient(authLoginRequestDto);
+
+        if(authLoginRequestDto.getSocialLoginUuid() != null) {
+            log.info("로그인 시도 - 소셜로그인uuid: {}", authLoginRequestDto.getSocialLoginUuid());
+            // 2. authRequestDto의 uuid를 기준으로 User 테이블에서 사용자 조회
+            userResponseDto = userService.getUserInfoByUuid(authLoginRequestDto.getSocialLoginUuid());
         }
 
-        // 2. userResponseDto 값이 null이면 회원가입 진행
+        // 3. userResponseDto 값이 null이면 회원가입 진행
         if(userResponseDto == null){
             userResponseDto = userService.saveNewUser(
-                userService.createNewUser(authRequestDto)
+                userService.createNewUser(authLoginRequestDto)
             );
         }else if(Boolean.TRUE.equals(userResponseDto.getIsDeleted())){
-            // 3. userResponseDto 에서 isdeleted가 true면 기존 회원정보 hardDelete 후 재가입
+            // 4. userResponseDto 에서 isdeleted가 true면 기존 회원정보 hardDelete 후 재가입
             // 기존 회원정보 삭제
             userService.hardDeleteUserByUuid(userResponseDto);
 
             // 재가입
             userResponseDto = userService.saveNewUser(
-                userService.createNewUser(authRequestDto)
+                userService.createNewUser(authLoginRequestDto)
             );
         }
 
-        // 4. 사용자 로그인시 위도/경도 변경시 db에 반영
-        userService.updateLocationIfChanged(userResponseDto.getUserId(), authRequestDto);
+        // 5. 사용자 로그인시 위도/경도 변경시 db에 반영
+        userService.updateLocationIfChanged(userResponseDto.getUserId(), authLoginRequestDto);
 
-        // 5. Access/Refresh Token 생성
+        // 6. Access/Refresh Token 생성
         String accessToken = jwtUtil.createJwt("access", userResponseDto, accessTokenExpiredMs);
         String refreshToken = jwtUtil.createJwt("refresh", userResponseDto, refreshTokenExpiredMs);
 
-        // 6. Refresh토큰 Redis에 저장
+        // 7. Refresh토큰 Redis에 저장
         refreshTokenService.saveRefreshToken(refreshToken, userResponseDto.getName());
 
-        // 7. 컨트롤러로 반환
+        // 8. 컨트롤러로 반환
         return createHttpHeader(accessToken, refreshToken);
+    }
+
+    public String preLogin(AuthPreLoginRequestDto authPreLoginRequestDto){
+        // 만료시간 테스트용으로 10시간 설정
+        // todo 10분으로 변경
+        return jwtUtil.createJwt("preLogin", authPreLoginRequestDto, 10*60*60*1000L);
     }
 
     public HttpHeaders refreshTokens(HttpServletRequest request){
@@ -117,10 +129,58 @@ public class AuthService {
 
         // 프론트 배포시 적용할 설정(https에서만 쿠키 전달 + 크로스 사이트 요청에 대해 쿠키 전송 허용)
         //return name + "=" + value + "; Path=/; HttpOnly; Secure; SameSite=None; Max-Age=" + (refreshTokenExpiredMs);
+    }
+    private void verifyClient(AuthLoginRequestDto authLoginRequestDto){
 
+        String codeVerifier = authLoginRequestDto.getCodeVerifier();
+        String preLoginJwt = authLoginRequestDto.getPreLoginJwt();
 
+        // 클라이언트 검증 절차 진행
+        if(codeVerifier == null || preLoginJwt == null) {
+            log.error("회원가입/로그인 실패 : codeVerifier or preLoginJwt null");
+            throw new CustomException(ResponseCodeEnum.MISSING_REQUIRED_FIELDS);
+        }
+
+        String codeChallenge = jwtUtil.getCodeChallenge(preLoginJwt);
+        String codeChallengeMethod = jwtUtil.getCodeChallengeMethod(preLoginJwt);
+
+        if(codeChallenge == null || codeChallengeMethod == null) {
+            log.error("회원가입/로그인 실패 : codeChallenge or codeChallengeMethod null");
+            throw new CustomException(ResponseCodeEnum.MISSING_REQUIRED_FIELDS);
+        }
+
+        if(codeChallengeMethod.equals("plain")){
+            if(!codeChallenge.equals(codeVerifier)){
+                throw new CustomException(ResponseCodeEnum.UNIDENTIFIED_CLIENT);
+            }
+        }else if(codeChallengeMethod.equals("S256")){
+            if(!generateCodeChallenge(codeVerifier).equals(codeChallenge)){
+                throw new CustomException(ResponseCodeEnum.UNIDENTIFIED_CLIENT);
+            }
+        }else{
+            throw new CustomException(ResponseCodeEnum.UNSUPPORTED_HASH_ALGORITHM);
+        }
     }
 
+    private String generateCodeChallenge(String codeVerifier) {
 
+        // 1. ASCII 인코딩
+        byte[] codeVerifierBytes = codeVerifier.getBytes(StandardCharsets.US_ASCII);
 
+        // 2. SHA-256 해시 계산
+        MessageDigest messageDigest = null;
+        try {
+            messageDigest = MessageDigest.getInstance("SHA-256");
+        } catch (NoSuchAlgorithmException e) {
+            throw new CustomException(ResponseCodeEnum.UNSUPPORTED_HASH_ALGORITHM);
+        }
+
+        byte[] codeVerifierHash = messageDigest.digest(codeVerifierBytes);
+
+        // 3. BASE64URL 인코딩
+        Encoder base64URLEncoder = Base64.getUrlEncoder().withoutPadding();
+
+        // 4. CodeChallenge 변환 결과 반환
+        return base64URLEncoder.encodeToString(codeVerifierHash);
+    }
 }

--- a/src/main/java/com/pawever/server/domain/user/service/UserService.java
+++ b/src/main/java/com/pawever/server/domain/user/service/UserService.java
@@ -4,10 +4,9 @@ import com.fasterxml.jackson.databind.ObjectMapper;
 import com.pawever.server.common.exception.CustomException;
 import com.pawever.server.common.response.ApiResponse;
 import com.pawever.server.common.response.ResponseCodeEnum;
-import com.pawever.server.domain.carehub.service.ShelterService;
 import com.pawever.server.domain.carehub.entity.Shelter;
 import com.pawever.server.domain.post.service.ImageService;
-import com.pawever.server.domain.user.dto.request.AuthRequestDto;
+import com.pawever.server.domain.user.dto.request.AuthLoginRequestDto;
 import com.pawever.server.domain.user.dto.request.UserProfileUpdateRequestDto;
 import com.pawever.server.domain.user.dto.response.StaffProfileResponseDto;
 import com.pawever.server.domain.user.dto.response.UserProfileResponseDto;
@@ -54,15 +53,15 @@ public class UserService {
             .build()).orElse(null);
     }
 
-    public User createNewUser(AuthRequestDto authRequestDto) {
+    public User createNewUser(AuthLoginRequestDto authLoginRequestDto) {
         return User.builder()
-            .name(authRequestDto.getName())
-            .email(authRequestDto.getEmail())
-            .profileImageUrl(authRequestDto.getProfileImageUrl())
-            .socialLoginUuid(authRequestDto.getSocialLoginUuid())
-            .socialLoginProvider(authRequestDto.getSocialLoginProvider())
-            .latitude(authRequestDto.getLatitude())
-            .longitude(authRequestDto.getLongitude())
+            .name(authLoginRequestDto.getName())
+            .email(authLoginRequestDto.getEmail())
+            .profileImageUrl(authLoginRequestDto.getProfileImageUrl())
+            .socialLoginUuid(authLoginRequestDto.getSocialLoginUuid())
+            .socialLoginProvider(authLoginRequestDto.getSocialLoginProvider())
+            .latitude(authLoginRequestDto.getLatitude())
+            .longitude(authLoginRequestDto.getLongitude())
             .role(Role.ROLE_USER)
             .isDeleted(false)
             .build();
@@ -216,16 +215,16 @@ public class UserService {
     }
 
     @Transactional
-    public void updateLocationIfChanged(Long userId, AuthRequestDto authRequestDto) {
+    public void updateLocationIfChanged(Long userId, AuthLoginRequestDto authLoginRequestDto) {
         User user = userRepository.findById(userId)
             .orElseThrow(() -> new CustomException(ResponseCodeEnum.USER_NOT_FOUND));
         // 입력된 위도, 경도 값이 존재하고, 기존 DB 값과 다를 경우 업데이트
-        if (authRequestDto.getLatitude() != null && authRequestDto.getLongitude() != null) {
-            if (!authRequestDto.getLatitude().equals(user.getLatitude()) ||
-                !authRequestDto.getLongitude().equals(user.getLongitude())) {
+        if (authLoginRequestDto.getLatitude() != null && authLoginRequestDto.getLongitude() != null) {
+            if (!authLoginRequestDto.getLatitude().equals(user.getLatitude()) ||
+                !authLoginRequestDto.getLongitude().equals(user.getLongitude())) {
 
-                user.setLatitude(authRequestDto.getLatitude());
-                user.setLongitude(authRequestDto.getLongitude());
+                user.setLatitude(authLoginRequestDto.getLatitude());
+                user.setLongitude(authLoginRequestDto.getLongitude());
                 userRepository.save(user);
             }
         }

--- a/src/main/resources/application-local.yml
+++ b/src/main/resources/application-local.yml
@@ -6,7 +6,7 @@ spring:
     password: ${DB_PASSWORD}
   data:
     redis:
-      host: ${REDIS_HOST}
+      host: ${REDIS_HOST_NAME}
       port: ${REDIS_PORT}
   sql:
     init:


### PR DESCRIPTION
## #️⃣연관된 이슈
> #149 

## 📝작업 내용
- 기존 로그인 방식에서 서버가 유저정보를 보내는 클라이언트를 검증하지 못하는 문제가 있어, PreLogin 및 Login 단계에서 유저정보를 보내는 클라이언트를 검증하는 로직을 추가하였습니다.
- OAuth2.0에서 보안을 강화하기 위해서 사용하는 PKCE 방식을 활용했습니다.
- 기존 PKCE 방식은 클라이언트로부터 Code Challenge 및 Code Challenge Method를 받아 서버에 저장하는데,  본 서비스가 Jwt를 이용한 인증을 사용한다는 점에서 Stateless한 상황을 유지하기 위해서 JWT에 Code Challenge 및 Code Challenge Method를 담아 다시 클라이언트로 보내는 방식으로 구현하였습니다.
- 프론트와 연결전이며, 추후 연결하는 과정에서 추가적인 수정이 일어날 경우, 수정사항 담은 PR 별도 생성하겠습니다.

## 💬리뷰 요구사항(선택)
- 확인하시고 커멘트 및 승인 부탁드립니다.

## ✅ 체크리스트
- [x] PR 제목 규칙 잘 지켰는가?
- [x] 추가/수정사항을 설명하였는가?
- [x] 이슈넘버를 적었는가?
