### PR TITLE
feat : InputStream이 try 블록 끝나면서 닫히지 않도록 변경

### DIFF
--- a/src/main/java/com/pawever/server/common/infra/IpGeoLocationProvider.java
+++ b/src/main/java/com/pawever/server/common/infra/IpGeoLocationProvider.java
@@ -19,9 +19,8 @@ public class IpGeoLocationProvider {
     public IpGeoLocationProvider() throws IOException {
         // 클래스패스에서 파일을 읽는다
         ClassPathResource classPathResource = new ClassPathResource("data/GeoLite2-City.mmdb");
-        try (InputStream dbStream = classPathResource.getInputStream()) {
-            ipGeoDatabaseReader = new DatabaseReader.Builder(dbStream).build();
-        }
+        InputStream dbStream = classPathResource.getInputStream();
+        this.ipGeoDatabaseReader = new DatabaseReader.Builder(dbStream).build();
     }
 
     public CityResponse getGeoLocationByIp(InetAddress inetAddress) {


### PR DESCRIPTION
## #️⃣연관된 이슈
#151

## 📝작업 내용
- ip에 대응되는 Geo Location을 조회하기 위해 GeoLite2-City.mmdb 파일을 불러오는 ipGeoDatabaseReader 클래스에서 기존 코드가 InputStream이 try 구문이 끝나면서 닫히게 되면서 DatabaseReader가 해당 스트림을 참조할때 오류가 발생하는 문제를 해결하였습니다.
- try 블록을 제거하였습니다.

## 💬리뷰 요구사항(선택)
- 확인하시고 승인 부탁드립니다.

## ✅ 체크리스트
- [x] PR 제목 규칙 잘 지켰는가?
- [x] 추가/수정사항을 설명하였는가?
- [x] 이슈넘버를 적었는가?
