### PR TITLE
fix : maxmind geoip db 바이너리 파일이 빌드과정에서 깨지는 현상 개선 위해 수정

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -107,6 +107,14 @@ dependencies {
 
 }
 
+tasks.named('processResources') {
+    exclude '**/*.mmdb'
+    from('src/main/resources/data') {
+        include '**/*.mmdb'
+        into 'data'
+    }
+}
+
 
 tasks.named('test') {
     useJUnitPlatform()


### PR DESCRIPTION
## #️⃣연관된 이슈
#151 

## 📝작업 내용
- maxmind geoip db 바이너리 파일이 빌드과정에서 깨지는 현상 개선 위해 수정했습니다.
- proecessResources 과정에서 배제하여 텍스트 파일로 취급되어 깨지는 현상을 방지하고 수동으로 jar파일로 복사합니다.

## 💬리뷰 요구사항(선택)
- 확인하시고 승인 부탁드립니다.

## ✅ 체크리스트
- [x] PR 제목 규칙 잘 지켰는가?
- [x] 추가/수정사항을 설명하였는가?
- [x] 이슈넘버를 적었는가?
