### PR TITLE
fix : GeoIp DB파일을 Jar에 포함시킬 경우, 조회가 불가하여 외부 파일로 추가

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -2,8 +2,10 @@ FROM openjdk:17-jdk-slim
 WORKDIR /app
 
 COPY build/libs/*SNAPSHOT.jar app.jar
+COPY src/main/resources/data/GeoLite2-City.mmdb /app/data/GeoLite2-City.mmdb
 
 # 추가
 RUN mkdir /app/settings
+RUN chmod +r /app/data/GeoLite2-City.mmdb
 
 CMD ["java", "-jar", "-Dspring.profiles.active=dev", "app.jar"]

--- a/src/main/java/com/pawever/server/common/infra/IpGeoLocationProvider.java
+++ b/src/main/java/com/pawever/server/common/infra/IpGeoLocationProvider.java
@@ -4,6 +4,7 @@ import com.maxmind.geoip2.DatabaseReader;
 import com.maxmind.geoip2.exception.GeoIp2Exception;
 import com.maxmind.geoip2.model.CityResponse;
 import java.io.File;
+import java.io.FileNotFoundException;
 import java.io.IOException;
 import java.io.InputStream;
 import java.net.InetAddress;
@@ -20,17 +21,20 @@ public class IpGeoLocationProvider {
     private final DatabaseReader ipGeoDatabaseReader;
 
     public IpGeoLocationProvider() throws IOException {
-        // 클래스패스에서 파일을 읽는다
-        ClassPathResource classPathResource = new ClassPathResource("data/GeoLite2-City.mmdb");
-        InputStream dbStream = classPathResource.getInputStream();
+        // 클래스패스에서 .mmdb 파일을 InputStream으로 읽음
+//        ClassPathResource classPathResource = new ClassPathResource("data/GeoLite2-City.mmdb");
+//        try (InputStream dbStream = classPathResource.getInputStream()) {
+//            this.ipGeoDatabaseReader = new DatabaseReader.Builder(dbStream).build();
+//        }
 
-        // 임시 파일 생성 (앱 종료 시 자동 삭제)
-        File tempFile = File.createTempFile("GeoLite2-City", ".mmdb");
-        tempFile.deleteOnExit();
-        Files.copy(dbStream, tempFile.toPath(), StandardCopyOption.REPLACE_EXISTING);
+        // Docker 이미지에 포함된 실제 파일 경로 (Dockerfile에 같이 복사 필요)
+        File dbFile = new File("/app/data/GeoLite2-City.mmdb");
 
-        // 임시 파일을 DatabaseReader에 넘김
-        this.ipGeoDatabaseReader = new DatabaseReader.Builder(tempFile).build();
+        if (!dbFile.exists()) {
+            throw new FileNotFoundException("GeoLite2 DB file not found at: " + dbFile.getAbsolutePath());
+        }
+
+        this.ipGeoDatabaseReader = new DatabaseReader.Builder(dbFile).build();
     }
 
     public CityResponse getGeoLocationByIp(InetAddress inetAddress) {


### PR DESCRIPTION
## #️⃣연관된 이슈
> #151

## 📝작업 내용
- Jar파일에 Geo Ip Db 파일을 추가할 경우, Resource Processing에서 파일이 깨지는 문제가 발생하여, Dockerfile을 통해 Spring 어플리케이션 컨테이너에 Db파일을 추가한 다음 어플리케이션 외부에서 File객체로 읽어오도록 수정하였습니다.

## 💬리뷰 요구사항(선택)
- 확인하시고 승인 부탁드립니다.

## ✅ 체크리스트
- [x] PR 제목 규칙 잘 지켰는가?
- [x] 추가/수정사항을 설명하였는가?
- [x] 이슈넘버를 적었는가?
