### PR TITLE
fix : GeoIp DB파일을 lfs로 업로드 함에 따라 githubactions 상에서 lfs pull하도록 설정

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -17,6 +17,10 @@ jobs:
     steps:
       - name: Github Repository 파일 불러오기
         uses: actions/checkout@v4
+      - name: Git LFS 설치 및 LFS 파일 pull
+        run: |
+          git lfs install
+          git lfs pull
       - name: JDK 17버전 설치
         uses: actions/setup-java@v4
         with:


### PR DESCRIPTION
## #️⃣연관된 이슈
> #151

## 📝작업 내용
- Geo Ip DB를 git lfs로 업로드하였는데 Githubactions 상에서 lfs pull을 별도로 하지 않아 binary 파일 본문이 아닌 포인터만 pull된 것으로 확인하였습니다.
- 이에 binary 파일 본문이 다운로드 될 수 있도록 deploy.yml에 lfs pull step을 추가하였습니다.

## 💬리뷰 요구사항(선택)
- 확인하시고 승인 부탁드립니다.

## ✅ 체크리스트
- [x] PR 제목 규칙 잘 지켰는가?
- [x] 추가/수정사항을 설명하였는가?
- [x] 이슈넘버를 적었는가?
