### PR TITLE
fix : 멀티쓰레드로 비동기 작업시 공유자원 생명주기가 달라서 발생하는 문제 해결

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -2,10 +2,10 @@ FROM openjdk:17-jdk-slim
 WORKDIR /app
 
 COPY build/libs/*SNAPSHOT.jar app.jar
-COPY src/main/resources/data/GeoLite2-City.mmdb /app/data/GeoLite2-City.mmdb
+#COPY src/main/resources/data/GeoLite2-City.mmdb /app/data/GeoLite2-City.mmdb
 
 # 추가
 RUN mkdir /app/settings
-RUN chmod +r /app/data/GeoLite2-City.mmdb
+#RUN chmod +r /app/data/GeoLite2-City.mmdb
 
 CMD ["java", "-jar", "-Dspring.profiles.active=dev", "app.jar"]

--- a/src/main/java/com/pawever/server/common/config/AsyncConfig.java
+++ b/src/main/java/com/pawever/server/common/config/AsyncConfig.java
@@ -3,12 +3,13 @@ package com.pawever.server.common.config;
 import java.util.concurrent.Executor;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
+import org.springframework.scheduling.annotation.AsyncConfigurer;
 import org.springframework.scheduling.annotation.EnableAsync;
 import org.springframework.scheduling.concurrent.ThreadPoolTaskExecutor;
 
 @Configuration
 @EnableAsync
-public class AsyncConfig {
+public class AsyncConfig implements AsyncConfigurer {
 
     @Bean
     public Executor customAsyncExecutor() {
@@ -18,5 +19,10 @@ public class AsyncConfig {
         executor.setThreadNamePrefix("Async-");     // 스레드 prefix
         executor.initialize();
         return executor;
+    }
+
+    @Override
+    public Executor getAsyncExecutor() {
+        return customAsyncExecutor();
     }
 }

--- a/src/main/java/com/pawever/server/common/infra/IpGeoLocationProvider.java
+++ b/src/main/java/com/pawever/server/common/infra/IpGeoLocationProvider.java
@@ -22,19 +22,19 @@ public class IpGeoLocationProvider {
 
     public IpGeoLocationProvider() throws IOException {
         // 클래스패스에서 .mmdb 파일을 InputStream으로 읽음
-//        ClassPathResource classPathResource = new ClassPathResource("data/GeoLite2-City.mmdb");
-//        try (InputStream dbStream = classPathResource.getInputStream()) {
-//            this.ipGeoDatabaseReader = new DatabaseReader.Builder(dbStream).build();
-//        }
-
-        // Docker 이미지에 포함된 실제 파일 경로 (Dockerfile에 같이 복사 필요)
-        File dbFile = new File("/app/data/GeoLite2-City.mmdb");
-
-        if (!dbFile.exists()) {
-            throw new FileNotFoundException("GeoLite2 DB file not found at: " + dbFile.getAbsolutePath());
+        ClassPathResource classPathResource = new ClassPathResource("data/GeoLite2-City.mmdb");
+        try (InputStream dbStream = classPathResource.getInputStream()) {
+            this.ipGeoDatabaseReader = new DatabaseReader.Builder(dbStream).build();
         }
 
-        this.ipGeoDatabaseReader = new DatabaseReader.Builder(dbFile).build();
+        // Docker 이미지에 포함된 실제 파일 경로 (Dockerfile에 같이 복사 필요)
+//        File dbFile = new File("/app/data/GeoLite2-City.mmdb");
+//
+//        if (!dbFile.exists()) {
+//            throw new FileNotFoundException("GeoLite2 DB file not found at: " + dbFile.getAbsolutePath());
+//        }
+//
+//        this.ipGeoDatabaseReader = new DatabaseReader.Builder(dbFile).build();
     }
 
     public CityResponse getGeoLocationByIp(InetAddress inetAddress) {

--- a/src/main/java/com/pawever/server/domain/user/dto/internal/LoginClientEnvironmentDto.java
+++ b/src/main/java/com/pawever/server/domain/user/dto/internal/LoginClientEnvironmentDto.java
@@ -1,0 +1,16 @@
+package com.pawever.server.domain.user.dto.internal;
+
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@Getter
+@Builder
+@NoArgsConstructor
+@AllArgsConstructor
+public class LoginClientEnvironmentDto {
+    String clientIp;
+    String clientOs;
+    String clientBrowser;
+}

--- a/src/main/java/com/pawever/server/domain/user/service/AuthService.java
+++ b/src/main/java/com/pawever/server/domain/user/service/AuthService.java
@@ -2,6 +2,7 @@ package com.pawever.server.domain.user.service;
 
 import com.pawever.server.common.exception.CustomException;
 import com.pawever.server.common.response.ResponseCodeEnum;
+import com.pawever.server.domain.user.dto.internal.LoginClientEnvironmentDto;
 import com.pawever.server.domain.user.dto.internal.LoginSecurityMailSendDto;
 import com.pawever.server.domain.user.dto.request.AuthLoginRequestDto;
 import com.pawever.server.domain.user.dto.request.AuthPreLoginRequestDto;
@@ -93,7 +94,9 @@ public class AuthService {
                     .userName(userResponseDto.getName())
                     .build();
 
-                mailSendService.sendLoginSecurityMail(loginSecurityMailSendDto, request);
+                LoginClientEnvironmentDto loginClientEnvironmentDto = clientInfoResolver.createLoginClientEnvironmentDto(request);
+
+                mailSendService.sendLoginSecurityMail(loginSecurityMailSendDto, loginClientEnvironmentDto);
             }
 
             // 5. 사용자 현재 접속 IP로 DB 정보 업데이트

--- a/src/main/java/com/pawever/server/domain/user/service/ClientInfoResolver.java
+++ b/src/main/java/com/pawever/server/domain/user/service/ClientInfoResolver.java
@@ -1,5 +1,6 @@
 package com.pawever.server.domain.user.service;
 
+import com.pawever.server.domain.user.dto.internal.LoginClientEnvironmentDto;
 import jakarta.servlet.http.HttpServletRequest;
 import java.net.InetAddress;
 import java.net.UnknownHostException;
@@ -15,49 +16,9 @@ import org.springframework.util.StringUtils;
 @Slf4j
 public class ClientInfoResolver {
 
-    public InetAddress getClientInetAddress(HttpServletRequest request) {
-        String clientIp = null;
+    public InetAddress getClientInetAddress(String clientIp) {
         InetAddress inetAddress = null;
-        boolean isIpInHeader = false;
-
-        // 1. 프록시/로드밸러서 사용시 클라이언트의 ip 주소 반환
-        List<String> headerList = new ArrayList<>();
-        headerList.add("X-Forwarded-For");
-        headerList.add("HTTP_CLIENT_IP");
-        headerList.add("HTTP_X_FORWARDED_FOR");
-        headerList.add("HTTP_X_FORWARDED");
-        headerList.add("HTTP_FORWARDED_FOR");
-        headerList.add("HTTP_FORWARDED");
-        headerList.add("Proxy-Client-IP");
-        headerList.add("WL-Proxy-Client-IP");
-        headerList.add("HTTP_VIA");
-        headerList.add("IPV6_ADR");
-
-        for (String header : headerList) {
-            clientIp = request.getHeader(header);
-            if (StringUtils.hasText(clientIp) && !"unknown".equalsIgnoreCase(clientIp)) {
-                isIpInHeader = true;
-                break;
-            }
-        }
-
-        // 2. 프록시/로드밸런서 없이 클라이언트->서버 직접 접속시 클라이언트 ip 주소 반환
-        if (!isIpInHeader) {
-            clientIp = request.getRemoteAddr();
-        }
-
-//         3. 로컬호스트에서 접근시 정확한 ip 추출을 위한 코드
-        if ("0:0:0:0:0:0:0:1".equals(clientIp) || "127.0.0.1".equals(clientIp)) {
-            InetAddress localHostInetAddress = null;
-            try {
-                localHostInetAddress = InetAddress.getLocalHost();
-            } catch (UnknownHostException e) {
-                log.error("[UnknownHostException] 클라이언트의 Ip주소를 확인할 수 없습니다 : {}",clientIp, e);
-            }
-            clientIp = localHostInetAddress.getHostAddress();
-        }
-
-        // 4. String ip -> InetAddress 변환
+        // String ip -> InetAddress 변환
         try {
             inetAddress = InetAddress.getByName(clientIp);
         } catch (UnknownHostException e) {
@@ -127,15 +88,55 @@ public class ClientInfoResolver {
         return request.getHeader("User-Agent").toLowerCase();
     }
     public String getClientIp(HttpServletRequest request) {
-        InetAddress clientInetAddress = this.getClientInetAddress(request);
 
         String clientIp = "UNKNOWN";
+        boolean isIpInHeader = false;
 
-        if(clientInetAddress != null){
-            clientIp = clientInetAddress.getHostAddress();
+        // 1. 프록시/로드밸러서 사용시 클라이언트의 ip 주소 반환
+        List<String> headerList = new ArrayList<>();
+        headerList.add("X-Forwarded-For");
+        headerList.add("HTTP_CLIENT_IP");
+        headerList.add("HTTP_X_FORWARDED_FOR");
+        headerList.add("HTTP_X_FORWARDED");
+        headerList.add("HTTP_FORWARDED_FOR");
+        headerList.add("HTTP_FORWARDED");
+        headerList.add("Proxy-Client-IP");
+        headerList.add("WL-Proxy-Client-IP");
+        headerList.add("HTTP_VIA");
+        headerList.add("IPV6_ADR");
+
+        for (String header : headerList) {
+            clientIp = request.getHeader(header);
+            if (StringUtils.hasText(clientIp) && !"unknown".equalsIgnoreCase(clientIp)) {
+                isIpInHeader = true;
+                break;
+            }
+        }
+
+        // 2. 프록시/로드밸런서 없이 클라이언트->서버 직접 접속시 클라이언트 ip 주소 반환
+        if (!isIpInHeader) {
+            clientIp = request.getRemoteAddr();
+        }
+
+        // 3. 로컬호스트에서 접근시 정확한 ip 추출을 위한 코드
+        if ("0:0:0:0:0:0:0:1".equals(clientIp) || "127.0.0.1".equals(clientIp)) {
+            InetAddress localHostInetAddress = null;
+            try {
+                localHostInetAddress = InetAddress.getLocalHost();
+            } catch (UnknownHostException e) {
+                log.error("[UnknownHostException] 클라이언트의 Ip주소를 확인할 수 없습니다 : {}",clientIp, e);
+            }
+            clientIp = localHostInetAddress.getHostAddress();
         }
 
         return clientIp;
     }
+    public LoginClientEnvironmentDto createLoginClientEnvironmentDto(HttpServletRequest request) {
 
+        return LoginClientEnvironmentDto.builder()
+            .clientIp(getClientIp(request))
+            .clientOs(getClientOs(request))
+            .clientBrowser(getClientBrowser(request))
+            .build();
+    }
 }

--- a/src/main/java/com/pawever/server/domain/user/service/MailSendService.java
+++ b/src/main/java/com/pawever/server/domain/user/service/MailSendService.java
@@ -1,5 +1,6 @@
 package com.pawever.server.domain.user.service;
 
+import com.pawever.server.domain.user.dto.internal.LoginClientEnvironmentDto;
 import com.pawever.server.domain.user.dto.internal.LoginSecurityMailSendDto;
 import com.pawever.server.domain.user.dto.response.IpGeoLocationDto;
 import jakarta.mail.MessagingException;
@@ -34,7 +35,7 @@ public class MailSendService {
     }
 
     @Async
-    public void sendLoginSecurityMail(LoginSecurityMailSendDto loginSecurityMailSendDto, HttpServletRequest request) {
+    public void sendLoginSecurityMail(LoginSecurityMailSendDto loginSecurityMailSendDto, LoginClientEnvironmentDto loginClientEnvironmentDto) {
         try {
             MimeMessage mimeMessage = mailSender.createMimeMessage();
             // 1. MimeMessage 객체 생성을 돕는 MimeMessageHelper객체 생성
@@ -45,9 +46,10 @@ public class MailSendService {
             context.setVariable("subject", loginSecurityMailSendDto.getSubject());   // 메일 제목
             context.setVariable("loginTime", ZonedDateTime.now(ZoneId.of("Asia/Seoul"))); // 로그인 시간(한국 시간 적용)
 
-            InetAddress clientInetAdderess = clientInfoResolver.getClientInetAddress(request);
+            String clientIp = loginClientEnvironmentDto.getClientIp();
 
-            String clientIp = clientInfoResolver.getClientIp(request);
+            InetAddress clientInetAdderess = clientInfoResolver.getClientInetAddress(clientIp);
+
             context.setVariable("clientIp", formatClientIp(clientIp)); // 로그인 ip
 
             String countryName = ipGeoLocationService.getGeoLocationByIp(clientInetAdderess)
@@ -55,8 +57,8 @@ public class MailSendService {
                 .orElse("Location : Unknown");
 
             context.setVariable("clientLocation",   countryName);  // 로그인 지역
-            context.setVariable("clientOs", clientInfoResolver.getClientOs(request));   // 로그인 os
-            context.setVariable("clientBrowser", clientInfoResolver.getClientBrowser(request));  // 로그인 browser
+            context.setVariable("clientOs", loginClientEnvironmentDto.getClientOs());   // 로그인 os
+            context.setVariable("clientBrowser", loginClientEnvironmentDto.getClientBrowser());  // 로그인 browser
 
             context.setVariable("userName", maskUserName(loginSecurityMailSendDto.getUserName()));  // 사용자 User 아이디(masking 추가)
 


### PR DESCRIPTION
## #️⃣연관된 이슈
> #151 

## 📝작업 내용
[작업1]
- 로그인 작업과 보안메일전송 작업을 멀티쓰레드 비동기로 작업하는 중, HttpServletRequest 객체를 공유하도록 구현하였는데, 로그인 작업 이 먼저 종료될 경우, 보안메일 전송 작업 쓰레드에서 HttpServletRequest를 더이상 참조하지 못해 예외가 발생합니다.
- 해당 문제를 해결하기 위해서 보안 메일 전송 메서드로 HttpServletRequest 객체 대신 Dto 객체에 필요한 정보를 복사하여 전달하도록 수정하였습니다.

[작업2]
- 쓰레드 풀을 등록하였으나, 등록한 쓰레드 풀 대신 SimpleAsyncTaskExecutor가 사용되는 문제를 해결하기 위해서 AsyncConfig 클래스가 AsyncConfigurer 인터페이스를 구현하도록 하고, getAsyncExecutor를 오버라이드해서 등록한 쓰레드풀이 사용될 수 있도록 하였습니다.


## 💬리뷰 요구사항(선택)
- 확인하시고 승인 부탁드립니다.

## ✅ 체크리스트
- [x] PR 제목 규칙 잘 지켰는가?
- [x] 추가/수정사항을 설명하였는가?
- [x] 이슈넘버를 적었는가?
